### PR TITLE
fix: support current Bun polter binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- Nothing yet.
+- Fixed native `polter` argument handling with current Bun standalone binaries.
+- Updated compatible runtime, Node.js type, and pnpm tooling dependencies.
 
 ## [2.1.2] - 2026-06-11
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "arkregex": "^0.0.5",
     "chalk": "^5.6.2",
     "commander": "^15.0.0",
-    "es-toolkit": "^1.47.0",
+    "es-toolkit": "^1.47.1",
     "fb-watchman": "^2.0.2",
     "glob": "^13.0.6",
     "node-notifier": "^10.0.1",
@@ -105,7 +105,7 @@
   "devDependencies": {
     "@steipete/oracle": "link:../oracle",
     "@types/fb-watchman": "^2.0.6",
-    "@types/node": "^25.9.2",
+    "@types/node": "^25.9.3",
     "@types/node-notifier": "^8.0.5",
     "@types/picomatch": "^4.0.3",
     "@types/write-file-atomic": "^4.0.3",
@@ -125,5 +125,5 @@
   "engines": {
     "node": ">=24.0.0"
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@10.34.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^15.0.0
         version: 15.0.0
       es-toolkit:
-        specifier: ^1.47.0
-        version: 1.47.0
+        specifier: ^1.47.1
+        version: 1.47.1
       fb-watchman:
         specifier: ^2.0.2
         version: 2.0.2
@@ -61,8 +61,8 @@ importers:
         specifier: ^2.0.6
         version: 2.0.6
       '@types/node':
-        specifier: ^25.9.2
-        version: 25.9.2
+        specifier: ^25.9.3
+        version: 25.9.3
       '@types/node-notifier':
         specifier: ^8.0.5
         version: 8.0.5
@@ -104,10 +104,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -713,8 +713,8 @@ packages:
   '@types/node-notifier@8.0.5':
     resolution: {integrity: sha512-LX7+8MtTsv6szumAp6WOy87nqMEdGhhry/Qfprjm1Ma6REjVzeF7SCyvPtp5RaF6IkXCS9V4ra8g5fwvf2ZAYg==}
 
-  '@types/node@25.9.2':
-    resolution: {integrity: sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==}
+  '@types/node@25.9.3':
+    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
   '@types/picomatch@4.0.3':
     resolution: {integrity: sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==}
@@ -885,8 +885,8 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
-  es-toolkit@1.47.0:
-    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
+  es-toolkit@1.47.1:
+    resolution: {integrity: sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==}
 
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
@@ -1748,7 +1748,7 @@ snapshots:
 
   '@types/fb-watchman@2.0.6':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/hast@3.0.4':
     dependencies:
@@ -1756,9 +1756,9 @@ snapshots:
 
   '@types/node-notifier@8.0.5':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
-  '@types/node@25.9.2':
+  '@types/node@25.9.3':
     dependencies:
       undici-types: 7.24.6
 
@@ -1768,7 +1768,7 @@ snapshots:
 
   '@types/write-file-atomic@4.0.3':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260609.1':
     optional: true
@@ -1813,7 +1813,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -1824,13 +1824,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -1915,7 +1915,7 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
-  es-toolkit@1.47.0: {}
+  es-toolkit@1.47.1: {}
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -2305,7 +2305,7 @@ snapshots:
 
   uuid@14.0.0: {}
 
-  vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2313,16 +2313,16 @@ snapshots:
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
       esbuild: 0.28.0
       fsevents: 2.3.3
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -2339,10 +2339,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
       '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
     transitivePeerDependencies:
       - msw

--- a/scripts/polter-bun.ts
+++ b/scripts/polter-bun.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env bun
 
-// Bun compiled binaries use argv[1] for the first user argument, so provide the
-// script path expected by the shared Node/Bun entrypoint guard.
-process.argv.splice(1, 0, "/polter");
+import { normalizePolterArgv } from "../src/utils/paths.js";
+
+// Older Bun binaries use argv[1] for the first user argument. Current binaries
+// provide a virtual bunfs script path, which must not be duplicated.
+process.argv = normalizePolterArgv(process.argv);
 await import("../src/polter.js");

--- a/src/polter.ts
+++ b/src/polter.ts
@@ -9,20 +9,12 @@ import {
 } from "./cli-shared/polter-command.js";
 import { PACKAGE_INFO } from "./cli/version.js";
 import { runWrapperWithDefaults } from "./polter/runner.js";
-import { isMainModule } from "./utils/paths.js";
+import { isMainModule, isPolterEntrypoint } from "./utils/paths.js";
 
 export { isBinaryFresh, resolveBinaryPath } from "./polter/binaries.js";
 export { runWrapper } from "./polter/runner.js";
 
-if (
-  process.argv[1] &&
-  (isMainModule() ||
-    process.argv[1].endsWith("/polter") ||
-    process.argv[1].endsWith("/polter.js") ||
-    process.argv[1].endsWith("/polter.ts") ||
-    process.argv[1].endsWith("\\polter.js") ||
-    process.argv[1].endsWith("\\polter.ts"))
-) {
+if (process.argv[1] && (isMainModule() || isPolterEntrypoint(process.argv[1]))) {
   const program = new Command();
 
   const polterCommand = program

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -6,6 +6,12 @@
 
 import { dirname } from "path";
 
+const POLTER_ENTRYPOINT_PATTERN = /(?:^|[\\/])polter(?:-(?:arm64|x64))?(?:\.(?:js|ts))?$/;
+
+export function isPolterEntrypoint(path: string | undefined): boolean {
+  return POLTER_ENTRYPOINT_PATTERN.test(path || "");
+}
+
 /**
  * Ensure Commander sees a script path at argv[1] for the standalone polter entrypoint.
  * Older Bun binaries omit it, while current Bun binaries expose a virtual bunfs path.
@@ -13,7 +19,7 @@ import { dirname } from "path";
 export function normalizePolterArgv(argv: string[]): string[] {
   const invocationPath = argv[1] || "";
   const hasBunVirtualScriptPath =
-    invocationPath.includes("$bunfs") && /(?:^|[\\/])polter(?:\.(?:js|ts))?$/.test(invocationPath);
+    invocationPath.includes("$bunfs") && isPolterEntrypoint(invocationPath);
 
   if (hasBunVirtualScriptPath) {
     return argv;

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -7,6 +7,22 @@
 import { dirname } from "path";
 
 /**
+ * Ensure Commander sees a script path at argv[1] for the standalone polter entrypoint.
+ * Older Bun binaries omit it, while current Bun binaries expose a virtual bunfs path.
+ */
+export function normalizePolterArgv(argv: string[]): string[] {
+  const invocationPath = argv[1] || "";
+  const hasBunVirtualScriptPath =
+    invocationPath.includes("$bunfs") && /(?:^|[\\/])polter(?:\.(?:js|ts))?$/.test(invocationPath);
+
+  if (hasBunVirtualScriptPath) {
+    return argv;
+  }
+
+  return [argv[0] || "polter", "/polter", ...argv.slice(1)];
+}
+
+/**
  * Get the directory name of the current module
  * Works around import.meta.url issues in Bun compiled binaries
  */

--- a/test/utils/paths.test.ts
+++ b/test/utils/paths.test.ts
@@ -4,6 +4,7 @@ import {
   getFilename,
   isCompiledBinary,
   isMainModule,
+  isPolterEntrypoint,
   normalizePolterArgv,
 } from "../../src/utils/paths.js";
 
@@ -51,6 +52,16 @@ describe.sequential("paths utilities", () => {
 
     expect(normalizePolterArgv(argv)).toBe(argv);
   });
+
+  it.each(["polter-arm64", "polter-x64"])(
+    "preserves Bun Homebrew slice argv for %s",
+    (sliceName) => {
+      const argv = ["/tmp/polter", `/$bunfs/root/${sliceName}`, "demo"];
+
+      expect(normalizePolterArgv(argv)).toBe(argv);
+      expect(isPolterEntrypoint(argv[1])).toBe(true);
+    },
+  );
 
   it("adds the missing polter script path for older Bun argv", () => {
     expect(normalizePolterArgv(["/tmp/polter", "demo"])).toEqual([

--- a/test/utils/paths.test.ts
+++ b/test/utils/paths.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getDirname, getFilename, isCompiledBinary, isMainModule } from "../../src/utils/paths.js";
+import {
+  getDirname,
+  getFilename,
+  isCompiledBinary,
+  isMainModule,
+  normalizePolterArgv,
+} from "../../src/utils/paths.js";
 
 describe.sequential("paths utilities", () => {
   const originalArgv = process.argv.slice();
@@ -38,6 +44,28 @@ describe.sequential("paths utilities", () => {
     process.argv = ["/tmp/$bunfs/poltergeist", ...originalArgv.slice(1)];
 
     expect(isCompiledBinary()).toBe(true);
+  });
+
+  it("preserves current Bun standalone polter argv", () => {
+    const argv = ["/tmp/polter", "/$bunfs/root/polter", "demo"];
+
+    expect(normalizePolterArgv(argv)).toBe(argv);
+  });
+
+  it("adds the missing polter script path for older Bun argv", () => {
+    expect(normalizePolterArgv(["/tmp/polter", "demo"])).toEqual([
+      "/tmp/polter",
+      "/polter",
+      "demo",
+    ]);
+  });
+
+  it("does not mistake an older Bun target named polter for a script path", () => {
+    expect(normalizePolterArgv(["/tmp/polter", "polter"])).toEqual([
+      "/tmp/polter",
+      "/polter",
+      "polter",
+    ]);
   });
 
   it("treats non-bun execPath as compiled binary", () => {


### PR DESCRIPTION
## Summary

- Refreshes the bounded compatible dependency set: `es-toolkit` 1.47.1, `@types/node` 25.9.3, and pnpm 10.34.3.
- Fixes native `polter` argument normalization for current Bun standalone binaries while preserving the older Bun layout.
- Keeps package version 2.1.2, Node >=24, pnpm 10, and all release state unchanged.

Latest preserved release: https://github.com/steipete/poltergeist/releases/tag/v2.1.2

## Dependency audit

- Every direct/dev dependency, GitHub Action, and declared toolchain was checked against current stable upstream state.
- `es-toolkit` 1.47.1: https://github.com/toss/es-toolkit/releases/tag/v1.47.1
- `@types/node` 25.9.3 source update: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/a166beb3b5889cd396ddca574e7305657c3de844
- pnpm 10.34.3: https://github.com/pnpm/pnpm/releases/tag/v10.34.3
- pnpm 11 is intentionally held as a separate risky major.
- The existing TypeScript native-preview nightly is intentionally not churned.
- `pnpm audit` reports zero vulnerabilities.

## Validation

- Focused tests: 31 passed.
- Full Vitest suite: 116 files passed, 2 skipped; 725 tests passed, 31 skipped.
- Typecheck, lint, format check, build, native Bun build, and package smoke passed.
- Exact final E2E passed all five real projects: C, Node TypeScript, Python, Go, and CMake.
- Structured review completed with no accepted/actionable findings.
- Public identifier gate passed across the exact diff, tests, fixtures, workflows, proof logs, package, binaries, and this PR body.

PR CI is green:

- https://github.com/steipete/poltergeist/actions/runs/27405365784
- https://github.com/steipete/poltergeist/actions/runs/27405365790

Current-main baseline CI was green:

- https://github.com/steipete/poltergeist/actions/runs/27392290097
- https://github.com/steipete/poltergeist/actions/runs/27392290091

## Exact CLI proof

The final packed tarball was installed into a disposable project using pnpm 10.34.3 and exercised against a real isolated Watchman 2026.06.08.00 server.

- Node and native `poltergeist --version` passed.
- Node and native `polter --version` passed.
- Daemon start, status, JSON status, manual rebuild, and stop passed.
- An excluded `.log` mutation did not rebuild during a 45-second observation.
- A watched source mutation rebuilt successfully.
- Node and native `polter` produced the expected target output.

Exact artifact SHA-256:

- Packed tarball: `0e5085fbed06e1811a3a0c3175d32e6e8653c3ab791fdf81e7faf3e6710450a7`
- Native `poltergeist`: `07525f16fa2c36bf186cd6a55352575159174d11a138c3750268d47d259953e4`
- Native `polter`: `8e7e217776d14839e3e59e9147c5d69e2d7d45d4c2e4ba486f718dc8159e7b69`

## Risk

- Low and bounded: two patch dependency updates, one same-major pnpm update, and a small argv compatibility helper covered by unit and exact native-binary proof.
- The host shared Watchman FSEvents service was unhealthy during final E2E, so the exact suite used a real isolated Watchman server with the kqueue watcher; all five projects passed.
- Existing `docs:api` missing-stylesheet behavior and the Vitest-specific `test:bun` harness are unrelated to this patch.

## Recommendation

Land. The patch is compatible, fully exercised through both shipped binaries, and leaves risky majors and nightly churn for separate work.