### PR TITLE
test: stabilize build error persistence wait

### DIFF
--- a/test/build-improvements.test.ts
+++ b/test/build-improvements.test.ts
@@ -13,12 +13,16 @@ vi.mock("child_process", () => ({
   execSync: vi.fn(() => "abc123"),
 }));
 
-async function waitForState<T>(reader: () => Promise<T>, timeoutMs: number = 750): Promise<T> {
+async function waitForState<T>(
+  reader: () => Promise<T>,
+  isReady: (value: T) => boolean,
+  timeoutMs: number = 750,
+): Promise<T> {
   const deadline = Date.now() + timeoutMs;
   let last: T;
   while (true) {
     last = await reader();
-    if (last) return last;
+    if (isReady(last)) return last;
     if (Date.now() >= deadline) return last;
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
@@ -213,7 +217,10 @@ describe("Build Improvements - Real-time Output & Error Capture", () => {
     expect(result.errorSummary).toBeDefined();
 
     // Read state to verify error context was stored (allowing async persistence)
-    const state = await waitForState(() => stateManager.readState("test-app"));
+    const state = await waitForState(
+      () => stateManager.readState("test-app"),
+      (value) => value?.lastBuildError !== undefined,
+    );
     expect(state?.lastBuildError).toBeDefined();
     expect(state?.lastBuildError?.exitCode).toBe(127);
     expect(state?.lastBuildError?.errorOutput).toContain("Fatal error: Cannot find module");


### PR DESCRIPTION
## Summary

- wait for the persisted build-error field, not merely for any state object
- keep timeout behavior so a missing persistence update still fails the existing assertions
- remove a race observed while validating the dependency queue

## Root cause

`initializeState()` makes `readState()` truthy before `updateBuildError()` finishes. The test helper returned on that initial state, so the fixed 50 ms delay sometimes left `lastBuildError` undefined. The helper now accepts a readiness predicate and waits for the field the test actually asserts.

## Proof

- Reproduced before the patch during the PR 180 full suite: `expected undefined to be defined` at `test/build-improvements.test.ts:217`.
- Focused test passed 15 consecutive stress runs after the patch. A later run under severe unrelated host CPU saturation timed out in a different test; the final normal focused run passed all 7 tests.
- `pnpm run build`: passed.
- `pnpm run typecheck`: passed.
- `pnpm run lint`: passed.
- `pnpm exec vitest --config vitest.config.ci.ts`: 113 files passed, 2 skipped; 702 tests passed, 31 skipped.
- `pnpm run build:bun:test`: built and executed both standalone binaries; both reported 2.1.2.
- `pnpm audit --audit-level high`: no known vulnerabilities.
- `~/.claude/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings; overall correctness 0.98.

Test-only change; no changelog entry.
