### PR TITLE
chore(deps): refresh release dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
 
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
 
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": []
+}

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "oracle": "oracle"
   },
   "dependencies": {
-    "@earendil-works/pi-tui": "^0.80.9",
+    "@earendil-works/pi-tui": "^0.80.10",
     "@logtape/logtape": "^2.1.3",
     "arkregex": "^0.0.8",
     "chalk": "^5.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@earendil-works/pi-tui':
-        specifier: ^0.80.9
-        version: 0.80.9
+        specifier: ^0.80.10
+        version: 0.80.10
       '@logtape/logtape':
         specifier: ^2.1.3
         version: 2.2.4
@@ -129,8 +129,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@earendil-works/pi-tui@0.80.9':
-    resolution: {integrity: sha512-unPTW8hRgIHEGjV8mJJ2jqm+fzgnRubes6V2FPk9ay1W9ZLofcpYQ3NDfrODXSci+oKbBpX9JyYUMfQV6jCA/A==}
+  '@earendil-works/pi-tui@0.80.10':
+    resolution: {integrity: sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.11.1':
@@ -1416,7 +1416,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@earendil-works/pi-tui@0.80.9':
+  '@earendil-works/pi-tui@0.80.10':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5


### PR DESCRIPTION
## Summary

- update `@earendil-works/pi-tui` from 0.80.9 to 0.80.10
- update `actions/setup-node` from v6 to v7 across CI, coverage, and release workflows
- add the generated Oxfmt config required by current Oxfmt for warning-free checks
- retain TypeScript 6.0.3 because TypeDoc 0.28.20 does not support TypeScript 7

## Proof

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm run lint` — 235 files formatted; no warnings after config addition
- `pnpm exec vitest --config vitest.config.ci.ts` — 113 files passed, 2 skipped; 702 tests passed, 31 skipped
- `pnpm run build:bun:test` — both native binaries built and reported 2.1.2
- `pnpm audit --audit-level high` — no known vulnerabilities
- scripted tmux panel session — panel rendered four targets and exited on `q`
- AutoReview — clean, 0.98 confidence

## Deferred dependency

TypeScript 7.0.2 installs, but `pnpm run docs:api` crashes in TypeDoc 0.28.20 because TypeDoc's peer range ends at TypeScript 6.0.x and it reads a removed compiler API. TypeScript remains at the latest compatible 6.0.3.

pnpm 11.13.1 rejects `@earendil-works/pi-tui@0.80.10` under its default 24-hour minimum-release-age policy because the package was published at 2026-07-16 22:04 UTC. pnpm remains at 10.34.3 so the release gate can install the newest TUI dependency without weakening the new policy; retry after the quarantine expires.
