### PR TITLE
fix: seal macOS release app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,12 @@ jobs:
           cd apps/mac
           xcodebuild -project Poltergeist.xcodeproj -scheme Poltergeist -configuration Debug build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 
+      - name: Validate macOS release scripts
+        run: |
+          bash -n apps/mac/scripts/build-release.sh
+          bash -n apps/mac/scripts/notarize-release.sh
+          bash -n apps/mac/scripts/verify-release.sh
+
       - name: Run SwiftLint
         run: |
           cd apps/mac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
     runs-on: macos-15
     env:
       POLTERGEIST_TEST_MODE: "true"
+      POLTERGEIST_CODESIGN_IDENTITY: "Developer ID Application: Peter Steinberger (Y5PE65HELJ)"
 
     steps:
       - name: Checkout code
@@ -76,10 +77,61 @@ jobs:
           cd apps/mac
           ./scripts/lint.sh
 
-      - name: Build macOS app (Release)
+      - name: Import personal Developer ID certificate
+        env:
+          MACOS_DEVELOPER_ID_P12: ${{ secrets.MACOS_DEVELOPER_ID_P12 }}
+          MACOS_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
         run: |
-          cd apps/mac
-          xcodebuild -project Poltergeist.xcodeproj -scheme Poltergeist -configuration Release -derivedDataPath build CLEAN_BUILD=YES CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" build
+          set -euo pipefail
+          test -n "$MACOS_DEVELOPER_ID_P12"
+          test -n "$MACOS_DEVELOPER_ID_P12_PASSWORD"
+
+          certificate_path="$RUNNER_TEMP/poltergeist-developer-id.p12"
+          keychain_path="$RUNNER_TEMP/poltergeist-signing.keychain-db"
+          ephemeral_keychain_passphrase="$(openssl rand -base64 32)"
+
+          printf '%s' "$MACOS_DEVELOPER_ID_P12" | base64 --decode > "$certificate_path"
+          security create-keychain -p "$ephemeral_keychain_passphrase" "$keychain_path"
+          security set-keychain-settings -lut 3600 "$keychain_path"
+          security unlock-keychain -p "$ephemeral_keychain_passphrase" "$keychain_path"
+          security import "$certificate_path" \
+            -k "$keychain_path" \
+            -P "$MACOS_DEVELOPER_ID_P12_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          rm -f "$certificate_path"
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$ephemeral_keychain_passphrase" \
+            "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
+          security find-identity -v -p codesigning "$keychain_path" | \
+            grep -F '"Developer ID Application: Peter Steinberger (Y5PE65HELJ)"'
+          echo "POLTERGEIST_CI_KEYCHAIN=$keychain_path" >> "$GITHUB_ENV"
+
+      - name: Build and sign macOS app (Release)
+        env:
+          POLTERGEIST_VERSION: ${{ github.ref_name }}
+          POLTERGEIST_BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          export POLTERGEIST_VERSION="${POLTERGEIST_VERSION#v}"
+          apps/mac/scripts/build-release.sh
+
+      - name: Notarize and staple macOS app
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+        run: |
+          apps/mac/scripts/notarize-release.sh \
+            apps/mac/build/Build/Products/Release/Poltergeist.app
+
+      - name: Verify Developer ID signature and Gatekeeper acceptance
+        run: |
+          apps/mac/scripts/verify-release.sh \
+            apps/mac/build/Build/Products/Release/Poltergeist.app
 
       - name: Package macOS app
         run: |
@@ -91,6 +143,13 @@ jobs:
           fi
           ARCHIVE_NAME="Poltergeist-${{ github.ref_name }}-macOS.zip"
           ditto -c -k --keepParent "$APP_PATH" "$ARCHIVE_NAME"
+
+      - name: Remove temporary signing keychain
+        if: always()
+        run: |
+          if [[ -n "${POLTERGEIST_CI_KEYCHAIN:-}" ]]; then
+            security delete-keychain "$POLTERGEIST_CI_KEYCHAIN" || true
+          fi
 
       - name: Upload macOS app artifacts
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed macOS release packaging to seal the complete app with the personal Developer ID identity, hardened runtime, notarization, stapling, stable designated-requirement checks, and Gatekeeper verification before publication.
+
 ## [2.1.3] - 2026-07-17
 
 ### Highlights

--- a/apps/mac/README.md
+++ b/apps/mac/README.md
@@ -84,6 +84,18 @@ make run
 ./distribute.sh
 ```
 
+### Release Signing
+
+Tag builds use `scripts/build-release.sh` to replace Xcode's linker ad-hoc signature with the personal Developer ID Application identity for team `Y5PE65HELJ`. The script seals the complete app bundle, enables the hardened runtime, and rejects any other signer or bundle identifier.
+
+GitHub Actions requires these repository secrets:
+
+- `MACOS_DEVELOPER_ID_P12`: base64-encoded PKCS#12 export containing `Developer ID Application: Peter Steinberger (Y5PE65HELJ)` and its private key.
+- `MACOS_DEVELOPER_ID_P12_PASSWORD`: password for that PKCS#12 export.
+- `APPLE_API_KEY_ID`, `APPLE_API_ISSUER_ID`, and `APPLE_API_PRIVATE_KEY`: App Store Connect API credentials accepted by `notarytool`.
+
+The release job imports the certificate into an ephemeral keychain, signs the app, submits it to Apple's notary service, staples the ticket, and only then creates the published zip. `scripts/verify-release.sh` enforces the stable bundle identifier and Developer ID designated requirement, checks the hardened runtime, runs strict deep signature verification, and requires local Gatekeeper acceptance.
+
 The app uses modern Xcode file system synchronized groups, so any files added to the `Poltergeist/` folder will automatically be included in the project.
 
 ## Usage

--- a/apps/mac/scripts/build-release.sh
+++ b/apps/mac/scripts/build-release.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$APP_ROOT/../.." && pwd)"
+
+readonly EXPECTED_IDENTITY="Developer ID Application: Peter Steinberger (Y5PE65HELJ)"
+readonly TEAM_ID="Y5PE65HELJ"
+
+SIGNING_IDENTITY="${POLTERGEIST_CODESIGN_IDENTITY:-$EXPECTED_IDENTITY}"
+DERIVED_DATA_PATH="${POLTERGEIST_DERIVED_DATA_PATH:-$APP_ROOT/build}"
+VERSION="${POLTERGEIST_VERSION:-$(node -p "JSON.parse(require('fs').readFileSync('$REPO_ROOT/package.json', 'utf8')).version")}"
+BUILD_NUMBER="${POLTERGEIST_BUILD_NUMBER:-1}"
+
+if [[ "$DERIVED_DATA_PATH" != /* || "$DERIVED_DATA_PATH" == "/" ]]; then
+    echo "Derived data path must be an absolute, non-root path: $DERIVED_DATA_PATH" >&2
+    exit 1
+fi
+
+if [[ "$SIGNING_IDENTITY" != "$EXPECTED_IDENTITY" ]]; then
+    echo "Refusing unexpected signing identity: $SIGNING_IDENTITY" >&2
+    echo "Expected: $EXPECTED_IDENTITY" >&2
+    exit 1
+fi
+
+if ! security find-identity -v -p codesigning | grep -Fq "\"$EXPECTED_IDENTITY\""; then
+    echo "Required signing identity is not available: $EXPECTED_IDENTITY" >&2
+    exit 1
+fi
+
+rm -rf "$DERIVED_DATA_PATH"
+
+xcodebuild \
+    -project "$APP_ROOT/Poltergeist.xcodeproj" \
+    -scheme Poltergeist \
+    -configuration Release \
+    -derivedDataPath "$DERIVED_DATA_PATH" \
+    -destination "generic/platform=macOS" \
+    CLEAN_BUILD=YES \
+    CODE_SIGNING_ALLOWED=NO \
+    CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGN_IDENTITY="" \
+    DEVELOPMENT_TEAM="$TEAM_ID" \
+    MARKETING_VERSION="$VERSION" \
+    CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+    clean build
+
+APP_PATH="$DERIVED_DATA_PATH/Build/Products/Release/Poltergeist.app"
+if [[ ! -d "$APP_PATH" ]]; then
+    echo "Built app not found: $APP_PATH" >&2
+    exit 1
+fi
+
+# Xcode leaves a linker ad-hoc signature when signing is disabled. Re-signing the
+# bundle replaces it and seals the executable, Info.plist, and all resources.
+codesign \
+    --force \
+    --options runtime \
+    --timestamp \
+    --sign "$SIGNING_IDENTITY" \
+    "$APP_PATH"
+
+"$SCRIPT_DIR/verify-release.sh" --skip-gatekeeper "$APP_PATH"
+
+printf '%s\n' "$APP_PATH"

--- a/apps/mac/scripts/notarize-release.sh
+++ b/apps/mac/scripts/notarize-release.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <Poltergeist.app>" >&2
+    exit 2
+}
+
+[[ $# -eq 1 ]] || usage
+
+APP_PATH="$1"
+[[ -d "$APP_PATH" ]] || { echo "App not found: $APP_PATH" >&2; exit 1; }
+
+if [[ -z "${APPLE_API_KEY_ID:-}" || -z "${APPLE_API_ISSUER_ID:-}" || -z "${APPLE_API_PRIVATE_KEY:-}" ]]; then
+    echo "App Store Connect API credentials are required" >&2
+    exit 1
+fi
+
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/poltergeist-notary.XXXXXX")"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+KEY_PATH="$TEMP_DIR/AuthKey_${APPLE_API_KEY_ID}.p8"
+SUBMISSION_ZIP="$TEMP_DIR/Poltergeist-notary-submission.zip"
+
+printf '%s\n' "$APPLE_API_PRIVATE_KEY" > "$KEY_PATH"
+chmod 600 "$KEY_PATH"
+ditto -c -k --keepParent "$APP_PATH" "$SUBMISSION_ZIP"
+
+xcrun notarytool submit "$SUBMISSION_ZIP" \
+    --key "$KEY_PATH" \
+    --key-id "$APPLE_API_KEY_ID" \
+    --issuer "$APPLE_API_ISSUER_ID" \
+    --wait
+
+xcrun stapler staple "$APP_PATH"
+xcrun stapler validate "$APP_PATH"

--- a/apps/mac/scripts/verify-release.sh
+++ b/apps/mac/scripts/verify-release.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly EXPECTED_BUNDLE_ID="me.steipete.poltergeist.monitor"
+readonly EXPECTED_AUTHORITY="Developer ID Application: Peter Steinberger (Y5PE65HELJ)"
+readonly EXPECTED_TEAM_ID="Y5PE65HELJ"
+readonly STABLE_REQUIREMENT="identifier \"$EXPECTED_BUNDLE_ID\" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = \"$EXPECTED_TEAM_ID\""
+
+usage() {
+    echo "Usage: $0 [--skip-gatekeeper] <Poltergeist.app>" >&2
+    exit 2
+}
+
+SKIP_GATEKEEPER=0
+if [[ "${1:-}" == "--skip-gatekeeper" ]]; then
+    SKIP_GATEKEEPER=1
+    shift
+fi
+[[ $# -eq 1 ]] || usage
+
+APP_PATH="$1"
+[[ -d "$APP_PATH" ]] || { echo "App not found: $APP_PATH" >&2; exit 1; }
+
+BUNDLE_ID="$(plutil -extract CFBundleIdentifier raw "$APP_PATH/Contents/Info.plist")"
+if [[ "$BUNDLE_ID" != "$EXPECTED_BUNDLE_ID" ]]; then
+    echo "Unexpected bundle identifier: $BUNDLE_ID" >&2
+    exit 1
+fi
+
+SIGNATURE_DETAILS="$(codesign -dvvv "$APP_PATH" 2>&1)"
+grep -Fq "Authority=$EXPECTED_AUTHORITY" <<< "$SIGNATURE_DETAILS" || {
+    echo "App is not signed by $EXPECTED_AUTHORITY" >&2
+    exit 1
+}
+grep -Fq "TeamIdentifier=$EXPECTED_TEAM_ID" <<< "$SIGNATURE_DETAILS" || {
+    echo "Unexpected or missing TeamIdentifier" >&2
+    exit 1
+}
+grep -Eq 'flags=.*\(runtime\)' <<< "$SIGNATURE_DETAILS" || {
+    echo "Hardened runtime flag is missing" >&2
+    exit 1
+}
+
+codesign --verify --strict --deep --verbose=2 "$APP_PATH"
+codesign --verify --strict --deep --verbose=2 -R="$STABLE_REQUIREMENT" "$APP_PATH"
+
+if [[ $SKIP_GATEKEEPER -eq 0 ]]; then
+    spctl --assess --type execute --verbose=4 "$APP_PATH"
+fi
+
+codesign -d -r- "$APP_PATH" 2>&1


### PR DESCRIPTION
## Summary

- replace the linker-only ad-hoc macOS app signature with the required personal Developer ID identity and hardened runtime
- notarize and staple the signed app before producing the release zip
- fail closed on the bundle identifier, team, signer, stable designated requirement, resource seal, and Gatekeeper assessment
- document the CI certificate and App Store Connect credential contract

## Root cause

The v2.1.3 tag workflow disabled Xcode signing and published the resulting app. Its executable retained only a linker ad-hoc signature, while the bundle resources were never sealed, so strict code-signature verification and Gatekeeper both failed with `code has no resources but signature indicates they must be present`.

## Proof

- reproduced the v2.1.3 failure with `codesign --verify --strict --deep` and `spctl --assess`
- applied the new signing command to that exact shipped bundle and passed strict deep verification, the stable Developer ID designated requirement, hardened-runtime inspection, and local Gatekeeper assessment (`source=Developer ID`)
- `shellcheck` for all three release scripts
- `actionlint` for CI and release workflows
- TypeScript build, format, lint, and typecheck gates
- macOS Swift format, SwiftLint, and test-source validation
- structured autoreview: clean, no accepted/actionable findings
