### PR TITLE
chore: prepare v2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Changelog
 
-## Unreleased
+## [2.1.4] - 2026-07-19
 
-- Fixed macOS release packaging to seal the complete app with the personal Developer ID identity, hardened runtime, notarization, stapling, stable designated-requirement checks, and Gatekeeper verification before publication.
+### Highlights
+
+- Restored trusted macOS app distribution with Developer ID signing, hardened runtime, notarization, stapling, and fail-closed release verification.
+
+### Fixed
+
+- Repaired the tag workflow so the complete app bundle is sealed with the personal Developer ID identity instead of retaining the linker-generated ad-hoc signature shipped in v2.1.3.
+- Added pre-publication checks for the bundle identifier, signing authority, team, hardened runtime, stable designated requirement, strict resource seal, notarization ticket, and Gatekeeper acceptance.
+
+### Maintenance
+
+- Documented the release certificate and App Store Connect credential contract and added shell and workflow lint coverage for the signing path.
 
 ## [2.1.3] - 2026-07-17
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steipete/poltergeist",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "The ghost that keeps your builds fresh - a universal file watcher with auto-rebuild for any language or build system",
   "keywords": [
     "automation",

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,2 +1,2 @@
 // Hardcoded at build time for compiled binaries; avoid filesystem reads.
-export const PACKAGE_INFO = { version: "2.1.3", name: "@steipete/poltergeist" };
+export const PACKAGE_INFO = { version: "2.1.4", name: "@steipete/poltergeist" };


### PR DESCRIPTION
## Summary

- curate the dated v2.1.4 changelog section with the macOS signing repair as the headline
- bump the npm package and shared CLI version metadata to 2.1.4
- keep the release prep focused; the compatible dependency audit found no available updates

## Proof

- TypeScript build and typecheck
- Oxfmt and Oxlint
- shellcheck for all macOS release scripts
- actionlint for CI and release workflows
- compiled Bun `poltergeist` and `polter` both report 2.1.4
- Swift build, SwiftLint, swift-format, and test-source validation
- structured autoreview: clean, no accepted/actionable findings

## Release plan

After this PR lands green, create the signed v2.1.4 tag and validate the complete Developer ID signing, notarization, stapling, Gatekeeper, npm, and Homebrew publication path.
