### PR TITLE
fix(state): stop truncating target names that contain hyphens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed target names containing hyphens being truncated to the last segment when reading state files, which made targets like `app-bundle` and `test-bundle` collide in `discoverStates()`
+- Corrected the exported `discoverStates()` map-key contract to use full stored target names, preventing hyphenated targets such as `app-bundle` and `test-bundle` from truncating and colliding. Thanks @devYRPauli.
 - Fixed `Poltergeist.listAllStates()` always returning an empty array; it rebuilt state paths through a `StateManager` rooted at `/` instead of reading the discovered files
 
 ## [2.1.4] - 2026-07-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- Nothing yet.
+- Fixed target names containing hyphens being truncated to the last segment when reading state files, which made targets like `app-bundle` and `test-bundle` collide in `discoverStates()`
+- Fixed `Poltergeist.listAllStates()` always returning an empty array; it rebuilt state paths through a `StateManager` rooted at `/` instead of reading the discovered files
 
 ## [2.1.4] - 2026-07-19
 

--- a/src/poltergeist.ts
+++ b/src/poltergeist.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { IntelligentBuildQueue } from "./build-queue.js";
 import { BuildCoordinator } from "./core/build-coordinator.js";
 import { ConfigReloadOrchestrator } from "./core/config-reload-orchestrator.js";
@@ -14,7 +16,7 @@ import type {
   IWatchmanConfigManager,
   PoltergeistDependencies,
 } from "./interfaces.js";
-import { createLogger, type Logger } from "./logger.js";
+import type { Logger } from "./logger.js";
 import { BuildNotifier } from "./notifier.js";
 import { PostBuildRunner } from "./post-build/post-build-runner.js";
 import { PriorityEngine } from "./priority-engine.js";
@@ -901,14 +903,16 @@ export class Poltergeist {
     const stateFiles = await StateManager.listAllStates();
     const states: PoltergeistState[] = [];
 
+    const stateDir = FileSystemUtils.getStateDirectory();
+
     for (const file of stateFiles) {
       try {
-        const stateManager = new StateManager("/", createLogger());
-        const targetName = file.replace(".state", "").split("-").pop() || "";
-        const state = await stateManager.readState(targetName);
-        if (state) {
-          states.push(state);
-        }
+        // Read each file directly. Deriving a target name from the file name
+        // and re-reading through a StateManager rooted at "/" rebuilt a path
+        // ("unknown-{hash of /}-{target}.state") that never matches a real
+        // state file, so this always returned an empty list.
+        const content = readFileSync(join(stateDir, file), "utf-8");
+        states.push(JSON.parse(content) as PoltergeistState);
       } catch {
         // Ignore invalid state files
       }

--- a/src/poltergeist.ts
+++ b/src/poltergeist.ts
@@ -21,7 +21,7 @@ import { BuildNotifier } from "./notifier.js";
 import { PostBuildRunner } from "./post-build/post-build-runner.js";
 import { PriorityEngine } from "./priority-engine.js";
 import { ExecutableRunner } from "./runners/executable-runner.js";
-import { type PoltergeistState, StateManager } from "./state.js";
+import { isPoltergeistState, type PoltergeistState, StateManager } from "./state.js";
 import type {
   BuildRequest,
   BuildSchedulingConfig,
@@ -40,28 +40,6 @@ import { WatchmanConfigManager } from "./watchman-config.js";
 
 export interface PoltergeistStartOptions {
   waitForInitialBuilds?: boolean;
-}
-
-function isPoltergeistState(value: unknown): value is PoltergeistState {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return false;
-  }
-
-  const state = value as Partial<PoltergeistState>;
-  return (
-    typeof state.version === "string" &&
-    typeof state.projectPath === "string" &&
-    typeof state.projectName === "string" &&
-    typeof state.target === "string" &&
-    state.target.length > 0 &&
-    typeof state.targetType === "string" &&
-    typeof state.configPath === "string" &&
-    typeof state.process?.pid === "number" &&
-    typeof state.process.hostname === "string" &&
-    typeof state.process.isActive === "boolean" &&
-    typeof state.process.startTime === "string" &&
-    typeof state.process.lastHeartbeat === "string"
-  );
 }
 
 export class Poltergeist {

--- a/src/poltergeist.ts
+++ b/src/poltergeist.ts
@@ -42,6 +42,28 @@ export interface PoltergeistStartOptions {
   waitForInitialBuilds?: boolean;
 }
 
+function isPoltergeistState(value: unknown): value is PoltergeistState {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const state = value as Partial<PoltergeistState>;
+  return (
+    typeof state.version === "string" &&
+    typeof state.projectPath === "string" &&
+    typeof state.projectName === "string" &&
+    typeof state.target === "string" &&
+    state.target.length > 0 &&
+    typeof state.targetType === "string" &&
+    typeof state.configPath === "string" &&
+    typeof state.process?.pid === "number" &&
+    typeof state.process.hostname === "string" &&
+    typeof state.process.isActive === "boolean" &&
+    typeof state.process.startTime === "string" &&
+    typeof state.process.lastHeartbeat === "string"
+  );
+}
+
 export class Poltergeist {
   private config: PoltergeistConfig;
   private projectRoot: string;
@@ -912,7 +934,10 @@ export class Poltergeist {
         // ("unknown-{hash of /}-{target}.state") that never matches a real
         // state file, so this always returned an empty list.
         const content = readFileSync(join(stateDir, file), "utf-8");
-        states.push(JSON.parse(content) as PoltergeistState);
+        const state: unknown = JSON.parse(content);
+        if (isPoltergeistState(state)) {
+          states.push(state);
+        }
       } catch {
         // Ignore invalid state files
       }

--- a/src/state.ts
+++ b/src/state.ts
@@ -59,6 +59,28 @@ export interface PoltergeistState {
   postBuildResults?: Record<string, PostBuildResult>;
 }
 
+export function isPoltergeistState(value: unknown): value is PoltergeistState {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const state = value as Partial<PoltergeistState>;
+  return (
+    typeof state.version === "string" &&
+    typeof state.projectPath === "string" &&
+    typeof state.projectName === "string" &&
+    typeof state.target === "string" &&
+    state.target.length > 0 &&
+    typeof state.targetType === "string" &&
+    typeof state.configPath === "string" &&
+    typeof state.process?.pid === "number" &&
+    typeof state.process.hostname === "string" &&
+    typeof state.process.isActive === "boolean" &&
+    typeof state.process.startTime === "string" &&
+    typeof state.process.lastHeartbeat === "string"
+  );
+}
+
 export class StateManager implements IStateManager {
   private logger: Logger;
   private projectRoot: string;
@@ -497,7 +519,11 @@ export class StateManager implements IStateManager {
       if (file.endsWith(".state")) {
         try {
           const content = readFileSync(join(this.stateDir, file), "utf-8");
-          const state = JSON.parse(content) as PoltergeistState;
+          const state: unknown = JSON.parse(content);
+          if (!isPoltergeistState(state)) {
+            this.logger.debug(`Skipping invalid state file ${file}`);
+            continue;
+          }
           // Take the target from the state itself. State file names are
           // {projectName}-{pathHash}-{targetName}.state, so splitting on "-"
           // truncates any target whose name contains a hyphen.

--- a/src/state.ts
+++ b/src/state.ts
@@ -498,8 +498,10 @@ export class StateManager implements IStateManager {
         try {
           const content = readFileSync(join(this.stateDir, file), "utf-8");
           const state = JSON.parse(content) as PoltergeistState;
-          const targetName = file.replace(".state", "").split("-").pop() || "";
-          states[targetName] = state;
+          // Take the target from the state itself. State file names are
+          // {projectName}-{pathHash}-{targetName}.state, so splitting on "-"
+          // truncates any target whose name contains a hyphen.
+          states[state.target] = state;
         } catch (error) {
           this.logger.debug(`Failed to read state file ${file}: ${error}`);
         }

--- a/test/state-hyphenated-target.test.ts
+++ b/test/state-hyphenated-target.test.ts
@@ -1,0 +1,94 @@
+// Regression tests for reading state files whose target name contains a hyphen.
+
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Logger } from "../src/logger.js";
+import { Poltergeist } from "../src/poltergeist.js";
+import { type PoltergeistState, StateManager } from "../src/state.js";
+
+const mockLogger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  success: vi.fn(),
+};
+
+const PROJECT_ROOT = "/test/myapp";
+
+function stateFor(target: string): PoltergeistState {
+  return {
+    version: "1.0",
+    projectPath: PROJECT_ROOT,
+    projectName: "myapp",
+    target,
+    targetType: "app-bundle",
+    configPath: join(PROJECT_ROOT, "poltergeist.config.json"),
+    process: {
+      pid: process.pid,
+      isActive: true,
+      startTime: new Date().toISOString(),
+      lastHeartbeat: new Date().toISOString(),
+    },
+  } as PoltergeistState;
+}
+
+describe.skipIf(process.platform === "win32")("state files with hyphenated targets", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testDir = join(tmpdir(), `poltergeist-hyphen-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    process.env.POLTERGEIST_STATE_DIR = testDir;
+  });
+
+  afterEach(() => {
+    delete process.env.POLTERGEIST_STATE_DIR;
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("keys discoverStates by the full target name", async () => {
+    const stateManager = new StateManager(PROJECT_ROOT, mockLogger);
+    // Names are {projectName}-{pathHash}-{targetName}.state, so splitting on
+    // "-" and taking the last segment truncates "app-bundle" to "bundle".
+    writeFileSync(
+      join(testDir, "myapp-aafbde62-app-bundle.state"),
+      JSON.stringify(stateFor("app-bundle")),
+    );
+
+    const states = await stateManager.discoverStates();
+
+    expect(Object.keys(states)).toEqual(["app-bundle"]);
+    expect(states["app-bundle"]?.target).toBe("app-bundle");
+  });
+
+  it("does not collide when two targets share a last hyphen segment", async () => {
+    const stateManager = new StateManager(PROJECT_ROOT, mockLogger);
+    writeFileSync(
+      join(testDir, "myapp-aafbde62-app-bundle.state"),
+      JSON.stringify(stateFor("app-bundle")),
+    );
+    writeFileSync(
+      join(testDir, "myapp-aafbde62-test-bundle.state"),
+      JSON.stringify(stateFor("test-bundle")),
+    );
+
+    const states = await stateManager.discoverStates();
+
+    expect(Object.keys(states).sort()).toEqual(["app-bundle", "test-bundle"]);
+  });
+
+  it("returns states from Poltergeist.listAllStates", async () => {
+    writeFileSync(
+      join(testDir, "myapp-aafbde62-app-bundle.state"),
+      JSON.stringify(stateFor("app-bundle")),
+    );
+
+    const states = await Poltergeist.listAllStates();
+
+    expect(states.map((s) => s.target)).toEqual(["app-bundle"]);
+  });
+});

--- a/test/state-hyphenated-target.test.ts
+++ b/test/state-hyphenated-target.test.ts
@@ -93,4 +93,21 @@ describe.skipIf(process.platform === "win32")("state files with hyphenated targe
 
     expect(states.map((s) => s.target)).toEqual(["app-bundle"]);
   });
+
+  it("does not key discoverStates by 'undefined' for an incomplete state file", async () => {
+    // A syntactically valid but incomplete object (e.g. "{}") does not throw
+    // on JSON.parse, so state.target is undefined and, without validation,
+    // gets stored under the literal key "undefined".
+    writeFileSync(
+      join(testDir, "myapp-aafbde62-app-bundle.state"),
+      JSON.stringify(stateFor("app-bundle")),
+    );
+    writeFileSync(join(testDir, "myapp-aafbde62-empty.state"), "{}");
+
+    const stateManager = new StateManager(PROJECT_ROOT, mockLogger);
+    const states = await stateManager.discoverStates();
+
+    expect(Object.keys(states).sort()).toEqual(["app-bundle"]);
+    expect(states.undefined).toBeUndefined();
+  });
 });

--- a/test/state-hyphenated-target.test.ts
+++ b/test/state-hyphenated-target.test.ts
@@ -28,6 +28,7 @@ function stateFor(target: string): PoltergeistState {
     configPath: join(PROJECT_ROOT, "poltergeist.config.json"),
     process: {
       pid: process.pid,
+      hostname: "localhost",
       isActive: true,
       startTime: new Date().toISOString(),
       lastHeartbeat: new Date().toISOString(),
@@ -81,11 +82,12 @@ describe.skipIf(process.platform === "win32")("state files with hyphenated targe
     expect(Object.keys(states).sort()).toEqual(["app-bundle", "test-bundle"]);
   });
 
-  it("returns states from Poltergeist.listAllStates", async () => {
+  it("returns valid states and skips corrupted state files", async () => {
     writeFileSync(
       join(testDir, "myapp-aafbde62-app-bundle.state"),
       JSON.stringify(stateFor("app-bundle")),
     );
+    writeFileSync(join(testDir, "myapp-aafbde62-corrupted.state"), "null");
 
     const states = await Poltergeist.listAllStates();
 


### PR DESCRIPTION
Two related defects in reading state files, both caused by deriving the target name from the file name.

State files are named `{projectName}-{pathHash}-{targetName}.state` (`FileSystemUtils.generateStateFileName`), so `file.replace(".state", "").split("-").pop()` truncates any target whose name contains a hyphen.

## 1. `StateManager.discoverStates()` misfiles and collides hyphenated targets

The truncated name is used as the key of the returned map, so a target named `app-bundle` is filed under `bundle`. Worse, two targets that share a last segment collapse into one entry and one state is silently dropped:

| State files present | Keys returned before | Keys returned after |
| --- | --- | --- |
| `myapp-aafbde62-app-bundle.state` | `["bundle"]` | `["app-bundle"]` |
| ...plus `myapp-aafbde62-test-bundle.state` | `["bundle"]` (one state lost) | `["app-bundle", "test-bundle"]` |

`app-bundle` is one of the documented target types, so hyphenated target names are expected rather than exotic.

The fix reads `state.target` from the file that was just parsed. The writer already records it, so no parsing is needed and the value cannot disagree with the file.

## 2. `Poltergeist.listAllStates()` always returned an empty array

Same parse, plus a second problem that makes the parse irrelevant. It fed the derived name to a `StateManager` rooted at `"/"`:

```ts
const stateManager = new StateManager("/", createLogger());
const targetName = file.replace(".state", "").split("-").pop() || "";
const state = await stateManager.readState(targetName);
```

`readState` rebuilds the path via `getStateFilePath`, so with `projectRoot = "/"` it looks for `unknown-8a5edab2-{target}.state` (`projectName` resolves to `"unknown"`, and the hash is of `/`). That never matches a real file, so the method returned `[]` regardless of what was on disk. Correcting the target name alone would not have helped.

Since the file names are already in hand, the fix reads each one directly.

## Verification

Added `test/state-hyphenated-target.test.ts`. All three cases **fail against unpatched `main`**:

```
AssertionError: expected [ 'bundle' ] to deeply equal [ 'app-bundle' ]
AssertionError: expected [ 'bundle' ] to deeply equal [ 'app-bundle', 'test-bundle' ]
AssertionError: expected [] to deeply equal [ 'app-bundle' ]
```

and pass with it.

- New tests: 3 passed
- `state-edge-cases` + new suite: 19 passed, 1 skipped
- Wider run across 12 suites touching `poltergeist.ts` / `state.ts`: 85 passed, 0 failed
- `oxfmt --check` clean; `tsgo --noEmit` reports no errors in the changed files

Two suites (`agent-commands`, `cli`) fail to load locally with `Cannot find package '@earendil-works/pi-tui'`. That reproduces identically on unpatched `main`, so it is a local dependency issue rather than a regression.

`createLogger` became unused in `poltergeist.ts` and was dropped from the import. CHANGELOG entries added under Unreleased in the existing one-line style.

## Note on reachability

Neither method has a caller inside `src/` today. `discoverStates()` is on the `IStateManager` interface and is mocked across the test suite, so it is public API that consumers can call; `Poltergeist.listAllStates()` is exported as well. Happy to drop the second half if you would rather delete that method than fix it.


## Follow-up: validate parsed state records

Good catch on the review - the new direct-read path pushed `JSON.parse` output into `PoltergeistState[]` behind a bare type assertion, so a corrupted-but-syntactically-valid `.state` file (`null`, `[]`, `{}`) landed in the returned array and broke callers reading `state.target`.

Added an `isPoltergeistState()` guard and made the loop skip anything that fails it, which matches how the loop already ignores unparseable files. The guard checks exactly the non-optional fields of `PoltergeistState` (`version`, `projectPath`, `projectName`, non-empty `target`, `targetType`, `configPath`) plus the required fields of the nested `ProcessInfo` (`pid`, `hostname`, `isActive`, `startTime`, `lastHeartbeat`). Optional fields (`lastBuild`, `appInfo`, `buildStats`, `lastBuildError`, `postBuildResults`) are deliberately not checked, so real state files written by `ProcessManager.createProcessInfo()` always satisfy it.

## Real-behavior proof

Against a real temp state directory containing one valid state file with a hyphenated target plus two corrupted files (`null` and `{}`):

```
=== Files written ===
myapp-aafbde62-app-bundle.state (valid, target='app-bundle')
myapp-aafbde62-corrupted-null.state (contents: null)
myapp-aafbde62-corrupted-empty.state (contents: {})

########## AFTER FIX ##########
=== Poltergeist.listAllStates() result ===
[
  {
    "target": "app-bundle"
  }
]
PASS: hyphenated target 'app-bundle' returned correctly, exactly 1 entry
PASS: no corrupted/null/empty entries leaked into the returned array

########## BEFORE FIX (same script, change stashed) ##########
=== Poltergeist.listAllStates() result ===
TypeError: Cannot read properties of null (reading 'target')
    at Array.map (<anonymous>)
```

So the reported failure mode is real and reproducible, not theoretical: the caller crashes on the poisoned entry before the fix and gets a clean single result after it.

Tests: `test/state-hyphenated-target.test.ts` and `test/poltergeist.test.ts` -> 2 files, 29 passed. The regression test now writes a corrupted file alongside the hyphenated one and asserts only the valid entry comes back. `oxfmt --check` and `oxlint` clean on both touched files.

Note on repo-wide checks: `pnpm typecheck` and `pnpm lint` fail on this machine for reasons unrelated to this branch (a missing `@earendil-works/pi-tui` module and a formatting issue in `src/panel/panel-app.ts`); I confirmed both failures reproduce identically with my change stashed.


### Follow-up: same guard applied to the discoverStates map key

You are right, and this one is on me: changing the map key from the filename suffix to `state.target` is exactly what made this path reachable, so it is a regression this PR introduced rather than a pre-existing issue.

A file containing `null` throws on the property read and is already swallowed by the surrounding try/catch, which is why I initially thought `discoverStates()` was safe. But `{}` does not throw: `state.target` is `undefined`, so the record was stored under the literal key `"undefined"` instead of being ignored. Confirmed before changing anything:

```
Before fix: Object.keys(states) === [ 'undefined' ]
After fix:  Object.keys(states) === [ 'app-bundle' ]   (states.undefined === undefined)
```

Rather than duplicating the check, I moved `isPoltergeistState()` into `state.ts` next to the `PoltergeistState` definition, exported it, and imported it from `poltergeist.ts`. Its field checks are unchanged, so both call sites now enforce the same contract. Invalid records are skipped with a debug log, matching how the loop already reports unreadable files.

Added a regression test asserting an incomplete `{}` state file produces no `"undefined"` key.

```
$ npx vitest run test/state-hyphenated-target.test.ts test/poltergeist.test.ts
 Test Files  2 passed (2)
      Tests  30 passed (30)

$ npx oxfmt --check src/state.ts src/poltergeist.ts test/state-hyphenated-target.test.ts
All matched files use the correct format.
```

On the other flagged risk, that correcting the keys from the truncated final-hyphen segment to the full target name changes observable output for consumers depending on the old truncated keys: that is the intended fix and I do not think it can be avoided while the bug is fixed, since the old keys were wrong and collided (`app-bundle` and `test-bundle` both landed under `bundle`, losing one). Happy to follow whatever you prefer if you would rather stage it differently.
