### PR TITLE
fix(release): strip Bun signatures before lipo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
 
       - name: Validate macOS release scripts
         run: |
+          bash -n scripts/package-macos-universal.sh
           bash -n apps/mac/scripts/build-release.sh
           bash -n apps/mac/scripts/notarize-release.sh
           bash -n apps/mac/scripts/verify-release.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,20 +197,7 @@ jobs:
           bun build scripts/polter-bun.ts --compile --target=bun-darwin-arm64 --outfile dist-homebrew/polter-arm64 --minify
           bun build scripts/polter-bun.ts --compile --target=bun-darwin-x64 --outfile dist-homebrew/polter-x64 --minify
 
-          case "$(uname -m)" in
-            arm64) native_arch="arm64" ;;
-            x86_64) native_arch="x64" ;;
-            *) echo "Unsupported runner architecture: $(uname -m)" >&2; exit 1 ;;
-          esac
-          test "$(dist-homebrew/poltergeist-${native_arch} --version)" = "${version}"
-          test "$(dist-homebrew/polter-${native_arch} --version)" = "${version}"
-
-          lipo -create dist-homebrew/poltergeist-arm64 dist-homebrew/poltergeist-x64 -output dist-homebrew/poltergeist
-          lipo -create dist-homebrew/polter-arm64 dist-homebrew/polter-x64 -output dist-homebrew/polter
-          chmod +x dist-homebrew/poltergeist dist-homebrew/polter
-
-          tar -C dist-homebrew -czf "poltergeist-macos-universal-v${version}.tar.gz" poltergeist polter
-          shasum -a 256 "poltergeist-macos-universal-v${version}.tar.gz" > "poltergeist-macos-universal-v${version}.tar.gz.sha256"
+          scripts/package-macos-universal.sh dist-homebrew "$version"
 
       - name: Upload Homebrew artifact
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Corrected the exported `discoverStates()` map-key contract to use full stored target names, preventing hyphenated targets such as `app-bundle` and `test-bundle` from truncating and colliding. Thanks @devYRPauli.
 - Fixed `Poltergeist.listAllStates()` always returning an empty array; it rebuilt state paths through a `StateManager` rooted at `/` instead of reading the discovered files
+- Stabilized universal Bun binary packaging by stripping cross-compiled ad-hoc signatures before `lipo` assembly and re-signing the combined binaries.
 - Updated runtime and development dependencies, including Chalk 6, pi-tui 0.83, LogTape 2.3, Vite 8.2, pnpm 11, and current Oxc tooling.
 
 ## [2.1.4] - 2026-07-19

--- a/docs/release.md
+++ b/docs/release.md
@@ -26,12 +26,15 @@ Steps
 
 3) Build Bun binaries  
    - `pnpm run build:bun:all`  
-   - Create universal macOS bundle:  
+   - Build the Homebrew slices and create the universal macOS bundle:
      ```bash
-     lipo -create dist-bun/poltergeist-bun-darwin-x64 dist-bun/poltergeist-bun-darwin-arm64 -output dist-bun/poltergeist-macos-universal
-     lipo -create dist-bun/polter-bun-darwin-x64 dist-bun/polter-bun-darwin-arm64 -output dist-bun/polter-macos-universal
-     tar -czf dist-bun/poltergeist-macos-universal-v<ver>.tar.gz -C dist-bun poltergeist-macos-universal polter-macos-universal
-     shasum -a 256 dist-bun/poltergeist-macos-universal-v<ver>.tar.gz
+     version=<ver>
+     mkdir -p dist-homebrew
+     bun build src/cli.ts --compile --target=bun-darwin-arm64 --outfile dist-homebrew/poltergeist-arm64 --minify
+     bun build src/cli.ts --compile --target=bun-darwin-x64 --outfile dist-homebrew/poltergeist-x64 --minify
+     bun build scripts/polter-bun.ts --compile --target=bun-darwin-arm64 --outfile dist-homebrew/polter-arm64 --minify
+     bun build scripts/polter-bun.ts --compile --target=bun-darwin-x64 --outfile dist-homebrew/polter-x64 --minify
+     scripts/package-macos-universal.sh dist-homebrew "$version"
      ```
 
 4) Homebrew (only if this project ships a formula)  

--- a/scripts/package-macos-universal.sh
+++ b/scripts/package-macos-universal.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <binary-directory> <version>" >&2
+  exit 2
+fi
+
+binary_dir="$1"
+version="$2"
+
+for binary in poltergeist polter; do
+  arm64_slice="${binary_dir}/${binary}-arm64"
+  x64_slice="${binary_dir}/${binary}-x64"
+
+  for slice in "$arm64_slice" "$x64_slice"; do
+    test -x "$slice"
+    # Bun ad-hoc-signs compiled slices; cross-compiled signatures can make lipo die during kernel mmap validation.
+    codesign --remove-signature "$slice"
+    xattr -c "$slice"
+  done
+
+  lipo -create "$arm64_slice" "$x64_slice" -output "${binary_dir}/${binary}"
+  chmod +x "${binary_dir}/${binary}"
+  codesign --sign - --force "${binary_dir}/${binary}"
+done
+
+test "$("${binary_dir}/poltergeist" --version)" = "$version"
+test "$("${binary_dir}/polter" --version)" = "$version"
+
+archive="poltergeist-macos-universal-v${version}.tar.gz"
+tar -C "$binary_dir" -czf "$archive" poltergeist polter
+shasum -a 256 "$archive" > "${archive}.sha256"


### PR DESCRIPTION
## Summary

- strip Bun-generated signatures and extended attributes from both macOS slices before universal assembly
- ad-hoc re-sign each combined binary after `lipo`
- centralize the packaging contract in a reusable script used by CI and the release guide

## Root cause

Bun-compiled slices carry embedded signatures. The cross-compiled x64 slice's signature is not valid when the arm64 host kernel mmap-validates it, so `lipo` is killed with `Code Signature Invalid / Invalid Page` instead of returning a normal error.

## Proof

- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `bash -n scripts/package-macos-universal.sh`
- live four-slice assembly completed with exit 0
- both universal outputs report `x86_64 arm64`
- `codesign --verify --verbose=2` passes for both outputs
- built `poltergeist --version` and `polter --version` both report `2.1.5`
- generated archive passes `shasum -a 256 -c`
- `CI=true pnpm run lint`
- full suite: 114 test files passed, 5 skipped; 706 tests passed, 56 skipped
- autoreview: clean, no accepted/actionable findings
