### PR TITLE
chore(release): prepare 2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
-## [Unreleased]
+## [2.1.5] - 2026-08-02
+
+### Fixed
 
 - Corrected the exported `discoverStates()` map-key contract to use full stored target names, preventing hyphenated targets such as `app-bundle` and `test-bundle` from truncating and colliding. Thanks @devYRPauli.
-- Fixed `Poltergeist.listAllStates()` always returning an empty array; it rebuilt state paths through a `StateManager` rooted at `/` instead of reading the discovered files
+- Fixed `Poltergeist.listAllStates()` always returning an empty array; it rebuilt state paths through a `StateManager` rooted at `/` instead of reading the discovered files.
+
+### Maintenance
+
 - Stabilized universal Bun binary packaging by stripping cross-compiled ad-hoc signatures before `lipo` assembly and re-signing the combined binaries.
 - Updated runtime and development dependencies, including Chalk 6, pi-tui 0.83, LogTape 2.3, Vite 8.2, pnpm 11, and current Oxc tooling.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -21,8 +21,8 @@ Steps
 
 2) Clean gates  
    - `pnpm run lint`  
-   - `pnpm run test`  
    - `pnpm run build`
+   - `pnpm run test`
 
 3) Build Bun binaries  
    - `pnpm run build:bun:all`  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steipete/poltergeist",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "The ghost that keeps your builds fresh - a universal file watcher with auto-rebuild for any language or build system",
   "keywords": [
     "automation",

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,2 +1,2 @@
 // Hardcoded at build time for compiled binaries; avoid filesystem reads.
-export const PACKAGE_INFO = { version: "2.1.4", name: "@steipete/poltergeist" };
+export const PACKAGE_INFO = { version: "2.1.5", name: "@steipete/poltergeist" };


### PR DESCRIPTION
## Summary

- cut the approved 2.1.5 patch release in both version sources
- finalize the changelog with the corrected exported-key contract and contributor credit
- order the documented clean gates so integration tests run after their required `dist` build

## Proof

- frozen `CI=true` pnpm install
- lint and formatting clean
- build and typecheck clean
- full suite: 114 test files passed, 5 skipped; 706 tests passed, 56 skipped
- built Node `poltergeist` and `polter` both report `2.1.5`
- all Bun platform targets built
- four fresh macOS slices assembled into both universal binaries
- both universals report `x86_64 arm64`, pass `codesign --verify`, and execute as `2.1.5`
- universal archive checksum verified
- npm tarball packed as `@steipete/poltergeist@2.1.5`
- autoreview clean with no accepted/actionable findings
