### PR TITLE
chore: prepare next patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Nothing yet.
+
 ## [2.1.5] - 2026-08-02
 
 ### Fixed


### PR DESCRIPTION
## Summary

- restore the house-style Unreleased changelog section after publishing 2.1.5
- open the 2.1.6 development cycle without changing package versions

## Verification

- `git diff --check`
- autoreview clean with no accepted or actionable findings
- published 2.1.5 release notes and registry metadata verified before closeout
