### PR TITLE
fix(cli): read clean state files by path, not via the current project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed `clean` resolving every state file through a `StateManager` rooted at the current project, so files belonging to other projects were skipped and, when target names collided, the current project's file was removed while the output named a different one.
+- Fixed `clean` resolving every state file through a `StateManager` rooted at the current project, so files belonging to other projects were skipped and, when target names collided, the current project's file was removed while the output named a different one. Thanks @devYRPauli.
 - Restored TypeDoc API generation after the legacy documentation prune, repaired stale README links, and documented the TypeScript 6.x compatibility pin pending TypeDoc support for the TypeScript 7 compiler API.
 
 ## [2.1.5] - 2026-08-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed `clean` resolving every state file through a `StateManager` rooted at the current project, so files belonging to other projects were skipped and, when target names collided, the current project's file was removed while the output named a different one.
 - Restored TypeDoc API generation after the legacy documentation prune, repaired stale README links, and documented the TypeScript 6.x compatibility pin pending TypeDoc support for the TypeScript 7 compiler API.
 
 ## [2.1.5] - 2026-08-02

--- a/src/cli/commands/project.ts
+++ b/src/cli/commands/project.ts
@@ -283,6 +283,7 @@ export const registerProjectCommands = (program: Command): void => {
         const daysThreshold = Number.parseInt(options.days, 10);
         const ageThreshold = Date.now() - daysThreshold * msPerDay;
         const stateDir = FileSystemUtils.getStateDirectory();
+        const logger = createLogger();
         let removedCount = 0;
         let candidateCount = 0;
         const jsonReport: Array<Record<string, unknown>> = [];
@@ -394,7 +395,8 @@ export const registerProjectCommands = (program: Command): void => {
               removedCount++;
             } catch (error) {
               if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-                throw error;
+                const detail = error instanceof Error ? error.message : String(error);
+                logger.error(`Failed to remove state file ${file}: ${detail}`);
               }
             }
           }

--- a/src/cli/commands/project.ts
+++ b/src/cli/commands/project.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import type { Command } from "commander";
-import { existsSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import path, { join } from "path";
 import { createLogger } from "../../logger.js";
 import type { AppBundleTarget, PoltergeistConfig, ProjectType, Target } from "../../types.js";
@@ -14,7 +14,6 @@ import {
   generateDefaultConfig,
   guessBundleId,
 } from "../init-helpers.js";
-import { instantiateStateManager } from "../loaders.js";
 import { applyConfigOption } from "../options.js";
 import { exitWithError, loadConfigOrExit } from "../shared.js";
 
@@ -271,7 +270,7 @@ export const registerProjectCommands = (program: Command): void => {
       try {
         console.log(chalk.gray(poltergeistMessage("info", "Cleaning up state files...")));
 
-        const { StateManager } = await import("../../state.js");
+        const { StateManager, isPoltergeistState } = await import("../../state.js");
         const stateFiles = await StateManager.listAllStates();
 
         if (stateFiles.length === 0) {
@@ -279,11 +278,10 @@ export const registerProjectCommands = (program: Command): void => {
           return;
         }
 
-        const logger = createLogger();
         const msPerDay = 24 * 60 * 60 * 1000;
         const daysThreshold = Number.parseInt(options.days, 10);
         const ageThreshold = Date.now() - daysThreshold * msPerDay;
-        const fallbackProjectRoot = FileSystemUtils.findProjectRoot(process.cwd()) || process.cwd();
+        const stateDir = FileSystemUtils.getStateDirectory();
         let removedCount = 0;
         let candidateCount = 0;
         const jsonReport: Array<Record<string, unknown>> = [];
@@ -301,26 +299,22 @@ export const registerProjectCommands = (program: Command): void => {
           return fileName.replace(/\.state$/i, "");
         };
 
-        const readStateForFile = async (
-          manager: any,
-          file: string,
-          targetName: string,
-        ): Promise<any> => {
-          let state = await manager.readState(targetName);
-          if (!state) {
-            const fallbackName = file.replace(/\.state$/i, "");
-            if (fallbackName && fallbackName !== targetName) {
-              state = await manager.readState(fallbackName);
-            }
+        // Read the file being processed directly. Resolving it through a
+        // StateManager rooted at the current project would rebuild the path from
+        // that project root, so every file would resolve to the current
+        // project's state regardless of which file is being cleaned.
+        const readStateForFile = (file: string) => {
+          try {
+            const state: unknown = JSON.parse(readFileSync(join(stateDir, file), "utf-8"));
+            return isPoltergeistState(state) ? state : null;
+          } catch {
+            return null;
           }
-          return state;
         };
-
-        const stateManager = await instantiateStateManager(fallbackProjectRoot, logger);
 
         for (const file of stateFiles) {
           const targetName = deriveTargetName(file);
-          const state = await readStateForFile(stateManager, file, targetName);
+          const state = readStateForFile(file);
 
           if (!state) {
             continue;
@@ -382,8 +376,7 @@ export const registerProjectCommands = (program: Command): void => {
           console.log();
 
           if (!options.dryRun) {
-            const removalKey = state.target || targetName;
-            await stateManager.removeState(removalKey);
+            unlinkSync(join(stateDir, file));
             removedCount++;
           }
 

--- a/src/cli/commands/project.ts
+++ b/src/cli/commands/project.ts
@@ -7,6 +7,7 @@ import type { AppBundleTarget, PoltergeistConfig, ProjectType, Target } from "..
 import { CMakeProjectAnalyzer } from "../../utils/cmake-analyzer.js";
 import { FileSystemUtils } from "../../utils/filesystem.js";
 import { ghost, poltergeistMessage } from "../../utils/ghost.js";
+import { ProcessManager } from "../../utils/process-manager.js";
 import { WatchmanConfigManager } from "../../watchman-config.js";
 import {
   augmentConfigWithDetectedTargets,
@@ -306,7 +307,16 @@ export const registerProjectCommands = (program: Command): void => {
         const readStateForFile = (file: string) => {
           try {
             const state: unknown = JSON.parse(readFileSync(join(stateDir, file), "utf-8"));
-            return isPoltergeistState(state) ? state : null;
+            if (!isPoltergeistState(state)) {
+              return null;
+            }
+            // Refresh liveness from the recorded pid, as StateManager.readState()
+            // does. A process that died without updating its own state file still
+            // has isActive true on disk, and would never be treated as stale.
+            if (state.process.pid !== process.pid) {
+              state.process.isActive = ProcessManager.isProcessAlive(state.process.pid);
+            }
+            return state;
           } catch {
             return null;
           }
@@ -376,8 +386,17 @@ export const registerProjectCommands = (program: Command): void => {
           console.log();
 
           if (!options.dryRun) {
-            unlinkSync(join(stateDir, file));
-            removedCount++;
+            // A concurrent clean, or the owning process shutting down, can remove
+            // the file between the read above and here. That must not abort the
+            // rest of the pass, which is what removeState() used to absorb.
+            try {
+              unlinkSync(join(stateDir, file));
+              removedCount++;
+            } catch (error) {
+              if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+                throw error;
+              }
+            }
           }
 
           jsonReport.push({

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,7 +1,7 @@
 // Comprehensive tests for CLI commands
 
 import { cloneDeep, mergeWith } from "es-toolkit/object";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -143,7 +143,8 @@ vi.mock("../src/poltergeist.js", () => ({
   ),
 }));
 
-vi.mock("../src/state.js", () => ({
+vi.mock("../src/state.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/state.js")>()),
   StateManager: mockStateManager,
 }));
 
@@ -768,94 +769,78 @@ describe("CLI Commands", () => {
   });
 
   describe("clean command", () => {
+    // clean reads the state directory directly, so give each test its own.
+    let cleanStateDir: string;
+
+    beforeEach(() => {
+      cleanStateDir = mkdtempSync(join(tmpdir(), "poltergeist-cli-clean-"));
+      process.env.POLTERGEIST_STATE_DIR = cleanStateDir;
+      // state.js is mocked module-wide, so point the listing at the real directory.
+      mockStateManager.listAllStates = vi.fn(async () =>
+        readdirSync(cleanStateDir).filter((f) => f.endsWith(".state")),
+      );
+    });
+
+    afterEach(() => {
+      delete process.env.POLTERGEIST_STATE_DIR;
+      rmSync(cleanStateDir, { recursive: true, force: true });
+    });
+
+    const writeStateFile = (fileName: string, projectName: string, ageInDays: number) => {
+      writeFileSync(
+        join(cleanStateDir, fileName),
+        JSON.stringify({
+          version: "1.0",
+          projectPath: `/tmp/${projectName}`,
+          projectName,
+          target: fileName.replace(/^.*-([0-9a-f]{8})-/, "").replace(/\.state$/, ""),
+          targetType: "executable",
+          configPath: `/tmp/${projectName}/.poltergeist.json`,
+          process: {
+            pid: 999999,
+            hostname: "test-host",
+            isActive: ageInDays === 0,
+            startTime: new Date(0).toISOString(),
+            lastHeartbeat: new Date(Date.now() - ageInDays * 24 * 60 * 60 * 1000).toISOString(),
+          },
+        }),
+      );
+    };
+
     it("should clean stale state files", async () => {
       createTestConfig();
 
-      // Mock StateManager static method
-      mockStateManager.listAllStates = vi.fn(async () => ["old-state.state", "new-state.state"]);
-
-      // Mock StateManager instances
-      const oldStateManager = {
-        readState: vi.fn().mockResolvedValueOnce({
-          projectName: "old-project",
-          target: "old-target",
-          process: {
-            isActive: false,
-            lastHeartbeat: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(), // 10 days old
-          },
-        }),
-        removeState: vi.fn().mockResolvedValue(undefined),
-      };
-
-      const newStateManager = {
-        readState: vi.fn().mockResolvedValueOnce({
-          projectName: "new-project",
-          target: "new-target",
-          process: {
-            isActive: true,
-            lastHeartbeat: new Date().toISOString(),
-          },
-        }),
-        removeState: vi.fn().mockResolvedValue(undefined),
-      };
-
-      // Mock the StateManager constructor to return different instances
-      mockStateManager
-        .mockImplementationOnce(() => oldStateManager)
-        .mockImplementationOnce(() => newStateManager);
+      writeStateFile("old-project-11111111-old-target.state", "old-project", 10);
+      writeStateFile("new-project-22222222-new-target.state", "new-project", 0);
 
       const result = await runCLI(["clean"]);
-      expect(mockStateManager).toHaveBeenCalled();
-      const _usedStateManager = mockStateManager.mock.results.at(-1)?.value as {
-        removeState?: ReturnType<typeof vi.fn>;
-      };
 
       expect(result.exitCode).toBe(0);
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("Cleaning up state files"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining("Removed"));
+      // The stale file goes, the active one stays.
+      expect(existsSync(join(cleanStateDir, "old-project-11111111-old-target.state"))).toBe(false);
+      expect(existsSync(join(cleanStateDir, "new-project-22222222-new-target.state"))).toBe(true);
     });
 
     it("should support dry-run mode", async () => {
       createTestConfig();
 
-      // Mock some state files
-      mockStateManager.listAllStates = vi.fn(async () => ["test.state"]);
-      mockStateManager.mockImplementationOnce(() => ({
-        readState: vi.fn().mockResolvedValueOnce({
-          projectName: "test-project",
-          target: "test-target",
-          process: {
-            isActive: false,
-            lastHeartbeat: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(),
-          },
-        }),
-        removeState: vi.fn().mockResolvedValue(undefined),
-      }));
+      writeStateFile("test-project-33333333-test-target.state", "test-project", 10);
 
       const result = await runCLI(["clean", "--dry-run"]);
 
       expect(result.exitCode).toBe(0);
       expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining("Would remove"));
+      expect(existsSync(join(cleanStateDir, "test-project-33333333-test-target.state"))).toBe(true);
     });
 
     it("should clean all state files with --all flag", async () => {
       createTestConfig();
 
-      // Mock some state files
-      mockStateManager.listAllStates = vi.fn(async () => ["test.state"]);
-      mockStateManager.mockImplementationOnce(() => ({
-        readState: vi.fn().mockResolvedValueOnce({
-          projectName: "test-project",
-          target: "test-target",
-          process: {
-            isActive: true,
-            lastHeartbeat: new Date().toISOString(),
-          },
-        }),
-        removeState: vi.fn().mockResolvedValue(undefined),
-      }));
+      writeStateFile("test-project-44444444-test-target.state", "test-project", 0);
 
       const result = await runCLI(["clean", "--all", "--dry-run"]);
 
@@ -866,24 +851,12 @@ describe("CLI Commands", () => {
     it("should support custom days threshold", async () => {
       createTestConfig();
 
-      // Mock some state files
-      mockStateManager.listAllStates = vi.fn(async () => ["test.state"]);
-      mockStateManager.mockImplementationOnce(() => ({
-        readState: vi.fn().mockResolvedValueOnce({
-          projectName: "test-project",
-          target: "test-target",
-          process: {
-            isActive: false,
-            lastHeartbeat: new Date(Date.now() - 35 * 24 * 60 * 60 * 1000).toISOString(), // 35 days old
-          },
-        }),
-        removeState: vi.fn().mockResolvedValue(undefined),
-      }));
+      writeStateFile("test-project-55555555-test-target.state", "test-project", 35);
 
       const result = await runCLI(["clean", "--days", "30", "--dry-run"]);
 
       expect(result.exitCode).toBe(0);
-      // Would check for 30 days threshold in real implementation
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining("30+ days"));
     });
   });
 

--- a/test/cli/clean-json.test.ts
+++ b/test/cli/clean-json.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -113,6 +113,41 @@ describe("clean --json", () => {
     // The second file must still be cleaned rather than the pass aborting.
     expect(existsSync(join(stateDir, "zzz-5678efab-app.state"))).toBe(false);
     expect(readdirSync(stateDir)).toHaveLength(0);
+  });
+
+  it("reports an unlink failure and keeps cleaning later files", async () => {
+    const blockedPath = join(stateDir, "aaa-1234abcd-app.state");
+    const laterPath = join(stateDir, "zzz-5678efab-app.state");
+    writeState("aaa-1234abcd-app.state", "aaa", "/tmp/aaa");
+    writeState("zzz-5678efab-app.state", "zzz", "/tmp/zzz");
+
+    const program = new Command();
+    registerProjectCommands(program);
+    let loggedRemovalError = false;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      loggedRemovalError ||= String(args[0] ?? "").includes(
+        "Failed to remove state file aaa-1234abcd-app.state",
+      );
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      const line = String(args[0] ?? "");
+      if (line.includes("Removing:") && line.includes("aaa-1234abcd-app.state")) {
+        rmSync(blockedPath, { force: true });
+        mkdirSync(blockedPath);
+        writeFileSync(join(blockedPath, "still-in-use"), "blocked");
+      }
+    });
+
+    try {
+      await program.parseAsync(["clean", "--all", "--json"], { from: "user" });
+    } finally {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+
+    expect(existsSync(blockedPath)).toBe(true);
+    expect(existsSync(laterPath)).toBe(false);
+    expect(loggedRemovalError).toBe(true);
   });
 
   it("reports each file under its own project name", async () => {

--- a/test/cli/clean-json.test.ts
+++ b/test/cli/clean-json.test.ts
@@ -1,47 +1,90 @@
 import { Command } from "commander";
-import { describe, expect, it, vi } from "vitest";
-
-const listAllStatesMock = vi.fn();
-const removeStateMock = vi.fn();
-
-vi.mock("../../src/state.js", () => ({
-  StateManager: class {
-    static listAllStates = listAllStatesMock;
-    readState = vi.fn().mockResolvedValue({
-      projectName: "demo",
-      target: "app",
-      process: {
-        isActive: false,
-        lastHeartbeat: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(),
-      },
-    });
-    removeState = removeStateMock;
-  },
-}));
-
-vi.mock("../../src/logger.js", () => ({ createLogger: () => ({ info: vi.fn(), error: vi.fn() }) }));
-vi.mock("../../src/utils/filesystem.js", () => ({
-  FileSystemUtils: { findProjectRoot: () => "/tmp/project" },
-}));
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { registerProjectCommands } from "../../src/cli/commands/project.js";
 
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "poltergeist-clean-"));
+  process.env.POLTERGEIST_STATE_DIR = stateDir;
+});
+
+afterEach(() => {
+  delete process.env.POLTERGEIST_STATE_DIR;
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+// Both projects define a target called "app", which is what makes the two state
+// files collide when the target name is used to resolve them.
+const writeState = (fileName: string, projectName: string, projectPath: string) => {
+  writeFileSync(
+    join(stateDir, fileName),
+    JSON.stringify({
+      version: "1.0",
+      projectPath,
+      projectName,
+      target: "app",
+      targetType: "executable",
+      configPath: join(projectPath, ".poltergeist.json"),
+      process: {
+        pid: 999999,
+        hostname: "test-host",
+        isActive: false,
+        startTime: new Date(0).toISOString(),
+        lastHeartbeat: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+    }),
+  );
+};
+
+const runClean = async (args: string[]) => {
+  const program = new Command();
+  registerProjectCommands(program);
+  const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  await program.parseAsync(args, { from: "user" });
+  const output = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+  logSpy.mockRestore();
+  return output;
+};
+
 describe("clean --json", () => {
   it("outputs json summary and removes files", async () => {
-    listAllStatesMock.mockResolvedValue(["demo-1234-app.state"]);
-    removeStateMock.mockResolvedValue(undefined);
+    writeState("demo-1234abcd-app.state", "demo", "/tmp/demo");
 
-    const program = new Command();
-    registerProjectCommands(program);
-
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    await program.parseAsync(["clean", "--json"], { from: "user" });
-
-    const output = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
-    logSpy.mockRestore();
+    const output = await runClean(["clean", "--json"]);
 
     expect(output).toContain('"removed": 1');
-    expect(output).toContain("demo-1234-app.state");
-    expect(removeStateMock).toHaveBeenCalledTimes(1);
+    expect(output).toContain("demo-1234abcd-app.state");
+    expect(readdirSync(stateDir)).toHaveLength(0);
+  });
+
+  it("removes each state file it reports, not the current project's file", async () => {
+    // Two projects, both with an "app" target. Resolving a file by target name
+    // through a StateManager rooted at one project makes both names collide, so
+    // the wrong file gets read and removed.
+    writeState("demo-1234abcd-app.state", "demo", "/tmp/demo");
+    writeState("other-5678efab-app.state", "other", "/tmp/other");
+
+    const output = await runClean(["clean", "--all", "--json"]);
+
+    expect(output).toContain('"removed": 2');
+    expect(existsSync(join(stateDir, "demo-1234abcd-app.state"))).toBe(false);
+    expect(existsSync(join(stateDir, "other-5678efab-app.state"))).toBe(false);
+  });
+
+  it("reports each file under its own project name", async () => {
+    writeState("demo-1234abcd-app.state", "demo", "/tmp/demo");
+    writeState("other-5678efab-app.state", "other", "/tmp/other");
+
+    const output = await runClean(["clean", "--all", "--json", "--dry-run"]);
+
+    expect(output).toContain("demo");
+    expect(output).toContain("other");
+    // Nothing is removed in a dry run.
+    expect(readdirSync(stateDir)).toHaveLength(2);
   });
 });

--- a/test/cli/clean-json.test.ts
+++ b/test/cli/clean-json.test.ts
@@ -20,7 +20,12 @@ afterEach(() => {
 
 // Both projects define a target called "app", which is what makes the two state
 // files collide when the target name is used to resolve them.
-const writeState = (fileName: string, projectName: string, projectPath: string) => {
+const writeState = (
+  fileName: string,
+  projectName: string,
+  projectPath: string,
+  isActive = false,
+) => {
   writeFileSync(
     join(stateDir, fileName),
     JSON.stringify({
@@ -31,9 +36,10 @@ const writeState = (fileName: string, projectName: string, projectPath: string) 
       targetType: "executable",
       configPath: join(projectPath, ".poltergeist.json"),
       process: {
+        // Not a live pid, so liveness refresh resolves this to inactive.
         pid: 999999,
         hostname: "test-host",
-        isActive: false,
+        isActive,
         startTime: new Date(0).toISOString(),
         lastHeartbeat: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(),
       },
@@ -74,6 +80,39 @@ describe("clean --json", () => {
     expect(output).toContain('"removed": 2');
     expect(existsSync(join(stateDir, "demo-1234abcd-app.state"))).toBe(false);
     expect(existsSync(join(stateDir, "other-5678efab-app.state"))).toBe(false);
+  });
+
+  it("treats a state file as stale when its recorded process is gone", async () => {
+    // The owning process died without updating its own file, so isActive is
+    // still true on disk while the pid is long gone.
+    writeState("demo-1234abcd-app.state", "demo", "/tmp/demo", true);
+
+    const output = await runClean(["clean", "--json"]);
+
+    expect(output).toContain('"removed": 1');
+    expect(existsSync(join(stateDir, "demo-1234abcd-app.state"))).toBe(false);
+  });
+
+  it("keeps cleaning when a file disappears before it is removed", async () => {
+    writeState("aaa-1234abcd-app.state", "aaa", "/tmp/aaa");
+    writeState("zzz-5678efab-app.state", "zzz", "/tmp/zzz");
+
+    // Delete the first file after clean has read and announced it, but before
+    // it is unlinked, which is the concurrent-cleanup race.
+    const program = new Command();
+    registerProjectCommands(program);
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      const line = String(args[0] ?? "");
+      if (line.includes("Removing:") && line.includes("aaa-1234abcd-app.state")) {
+        rmSync(join(stateDir, "aaa-1234abcd-app.state"), { force: true });
+      }
+    });
+    await program.parseAsync(["clean", "--all", "--json"], { from: "user" });
+    logSpy.mockRestore();
+
+    // The second file must still be cleaned rather than the pass aborting.
+    expect(existsSync(join(stateDir, "zzz-5678efab-app.state"))).toBe(false);
+    expect(readdirSync(stateDir)).toHaveLength(0);
   });
 
   it("reports each file under its own project name", async () => {


### PR DESCRIPTION
## Problem

`clean` builds a single `StateManager` rooted at the current project and resolves every state file through it. `StateManager` rebuilds the path from its own `projectRoot`, so each iterated file resolves to the **current project's** state rather than the file actually being processed.

Two projects with a target of the same name is enough to trigger it, which is normal for anyone with more than one project using a `web` / `app` / `cli` target.

Two symptoms fall out of the same root cause:

- If the current project has a state file for that target name, the file named in the output is **not** the file removed.
- If it does not, the file is skipped entirely, so `clean --all` silently removes nothing.

Same family as the `listAllStates()` issue fixed in #195: a `StateManager` rooted at the wrong path reconstructing a filename instead of using the discovered one.

## Real behavior proof

Two projects, both with an `app` target, in an isolated `POLTERGEIST_STATE_DIR`. Run from `zeta-app`, built from this branch's parent and from this branch.

**Before (current main)** - names one file, deletes another:

```
$ ls $POLTERGEIST_STATE_DIR
  alpha-app-496a6fb2-app.state
  zeta-app-17bf9297-app.state

$ cd /tmp/pgdemo/zeta-app && poltergeist clean --all
  Cleaning up state files...
  Removing: alpha-app-496a6fb2-app.state
      Project: zeta-app
      Target: app
      Age: 30 days
      Reason: all files
  Removed 1 state file(s)

$ ls $POLTERGEIST_STATE_DIR
  alpha-app-496a6fb2-app.state
```

It announces `alpha-app-...`, prints `Project: zeta-app` on the very next line, deletes `zeta-app-...`, and leaves the file it named on disk.

**After (this branch)** - same fixture:

```
$ cd /tmp/pgdemo/zeta-app && poltergeist clean --all
  Cleaning up state files...
  Removing: zeta-app-17bf9297-app.state
      Project: zeta-app
  Removing: alpha-app-496a6fb2-app.state
      Project: alpha-app
  Removed 2 state file(s)

$ ls $POLTERGEIST_STATE_DIR
  (empty)
```

The skip-everything variant is also reproducible: when the current project has no state for the derived target name, `clean --all` reports `Removed 0 state file(s)` and leaves both files untouched.

## Fix

Read each file directly from the state directory and remove that exact path, matching how `discoverStates()` already reads state files. The per-project `StateManager` is no longer involved in the clean loop.

## Tests

The existing `clean` tests mocked `readState` to return a valid state for any file, which is exactly what hid the misattribution. They now write real state files into an isolated `POLTERGEIST_STATE_DIR` and assert which files survive.

Five tests across `test/cli.test.ts` and `test/cli/clean-json.test.ts` fail on the unpatched source and pass with the fix.

```
unpatched:  Tests  5 failed | 30 passed (35)
patched:    Tests  35 passed (35)
```

Full suite: `730 passed | 3 failed`. The 3 failures (`daemon-no-targets` x2, `init-command` CMake) are identical on unmodified `main` and unrelated to this change. `oxfmt`, `oxlint` and `tsgo --noEmit` are clean.

One note: `node_modules` in a fresh checkout was missing `@earendil-works/pi-tui`, which made `tsgo` report 13 errors and prevented the CLI from booting. `pnpm install --frozen-lockfile` resolved both without touching `package.json` or the lockfile.
