### PR TITLE
release: v2.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.1.6] - 2026-08-08
 
 - Removed the obsolete scoped-commit helper and allowed standard Git commands in isolated worktrees.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steipete/poltergeist",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "The ghost that keeps your builds fresh - a universal file watcher with auto-rebuild for any language or build system",
   "keywords": [
     "automation",

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,2 +1,2 @@
 // Hardcoded at build time for compiled binaries; avoid filesystem reads.
-export const PACKAGE_INFO = { version: "2.1.5", name: "@steipete/poltergeist" };
+export const PACKAGE_INFO = { version: "2.1.6", name: "@steipete/poltergeist" };


### PR DESCRIPTION
## Summary

- prepare the 2.1.6 patch release across package metadata, shared CLI version, and changelog

## Validation

- warning-free lint, typecheck, and build
- full suite: 117 files passed / 2 skipped; 736 tests passed / 31 skipped
- all-platform Bun builds completed
- local universal macOS archive contains `poltergeist` and `polter` fat binaries; both report 2.1.6
- structured autoreview — no actionable findings

The pre-release collision check found no v2.1.6 tag, GitHub Release, or npm version.
