### PR TITLE
fix: preserve executable settings during reloads

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -122,6 +122,12 @@ Use `--restart-signal` and `--restart-delay` when the process needs a particular
 
 For app bundles, backend frameworks, simulators, or devices, keep the daemon responsible for building and put relaunch or deployment work in the target's build or post-build commands. Per-target `settlingDelay` and `debounceInterval` values can reduce duplicate work after large file changes.
 
+Saving the configuration updates an existing executable target's build command, environment, output path, watch paths, and auto-run settings. An active build finishes with the settings it started with; subsequent builds and scheduled retries use the latest configuration. Changing a target's type replaces its specialized builder. Each successful build retains its output description and carries its own launch settings through a delayed restart, so a newer failed build cannot redirect that launch. Disabling auto-run cancels queued restarts and stops its child process. Configuration saves are applied in order, including saves made while a child is shutting down.
+
+Changes to post-build hook definitions or to settings of an existing non-executable target still require restarting the daemon.
+
+Repeated successful builds with the same target configuration coalesce into one pending restart. A successful build with a new configuration starts a fresh restart delay, even when the delay value is unchanged.
+
 ## Troubleshooting
 
 - Run `watchman --version` if the daemon cannot start watching.

--- a/src/build-queue.ts
+++ b/src/build-queue.ts
@@ -1,6 +1,7 @@
 // Intelligent Build Queue with Priority Management
 
 import type { BaseBuilder } from "./builders/index.js";
+import { outputForBuild } from "./core/build-context.js";
 import type { Logger } from "./logger.js";
 import type { BuildNotifier } from "./notifier.js";
 import type { PriorityEngine } from "./priority-engine.js";
@@ -10,6 +11,7 @@ import { FileSystemUtils } from "./utils/filesystem.js";
 
 interface QueuedBuild extends BuildRequest {
   builder: BaseBuilder;
+  registration: symbol;
   startTime?: number;
   retryCount: number;
 }
@@ -34,6 +36,7 @@ export class IntelligentBuildQueue {
   private pendingChangeFiles: Map<string, string[]> = new Map();
   private targetBuilders: Map<string, BaseBuilder> = new Map();
   private targets: Map<string, Target> = new Map();
+  private registrationIds = new Map<string, symbol>();
 
   // Statistics
   private queueStats = {
@@ -62,9 +65,27 @@ export class IntelligentBuildQueue {
    * Register a target with its builder
    */
   public registerTarget(target: Target, builder: BaseBuilder): void {
+    if (!this.registrationIds.has(target.name)) {
+      this.registrationIds.set(target.name, Symbol(target.name));
+    }
     this.targetBuilders.set(target.name, builder);
     this.targets.set(target.name, target);
+    for (const request of this.pendingQueue) {
+      if (request.target.name === target.name) {
+        request.target = target;
+        request.builder = builder;
+      }
+    }
     this.logger.debug(`Registered target: ${target.name}`);
+  }
+
+  public unregisterTarget(name: string): void {
+    this.cancelPendingBuilds(name);
+    this.pendingRebuilds.delete(name);
+    this.pendingChangeFiles.delete(name);
+    this.targetBuilders.delete(name);
+    this.targets.delete(name);
+    this.registrationIds.delete(name);
   }
 
   /**
@@ -175,6 +196,7 @@ export class IntelligentBuildQueue {
         triggeringFiles,
         id: this.generateRequestId(),
         builder,
+        registration: this.registrationIds.get(targetName)!,
         retryCount: 0,
       };
 
@@ -330,7 +352,7 @@ export class IntelligentBuildQueue {
           // eslint-disable-next-line no-console
           console.log("notify success", targetName, result);
         }
-        const outputInfo = builder?.getOutputInfo();
+        const outputInfo = outputForBuild(result, () => builder?.getOutputInfo());
         const message = BuildStatusManager.formatNotificationMessage(result, outputInfo);
         if (process.env.DEBUG_WAITS) {
           // eslint-disable-next-line no-console
@@ -517,9 +539,18 @@ export class IntelligentBuildQueue {
       `Retrying ${target.name} (attempt ${attemptNumber}/${maxRetries}) in ${delay}ms due to failure${errorMessage ? `: ${errorMessage}` : ""}`,
     );
 
+    const registration = request.registration;
     setTimeout(() => {
+      // Updates retain identity; removing and re-adding a name starts a new lifetime.
+      if (this.registrationIds.get(target.name) !== registration) return;
+      const currentTarget = this.targets.get(target.name);
+      const currentBuilder = this.targetBuilders.get(target.name);
+      if (!currentTarget || !currentBuilder || (currentTarget.maxRetries ?? 0) < attemptNumber)
+        return;
       const retryRequest: QueuedBuild = {
         ...request,
+        target: currentTarget,
+        builder: currentBuilder,
         id: this.generateRequestId(),
         timestamp: Date.now(),
         retryCount: attemptNumber,

--- a/src/builders/base-builder.ts
+++ b/src/builders/base-builder.ts
@@ -2,6 +2,8 @@
 import { type ChildProcess, execSync, spawn } from "child_process";
 import { createWriteStream, mkdirSync } from "fs";
 import { dirname } from "path";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { recordBuildOutput, recordBuildTarget } from "../core/build-context.js";
 import type { Logger } from "../logger.js";
 import type { StateManager } from "../state.js";
 import type { BuildProgress, BuildStatus, Target } from "../types.js";
@@ -39,14 +41,21 @@ export interface BuildOptions {
 }
 
 export abstract class BaseBuilder<T extends Target = Target> {
-  protected target: T;
+  private configuredTarget: T;
+  private readonly buildContext = new AsyncLocalStorage<T>();
+  protected get target(): T {
+    return this.buildContext.getStore() ?? this.configuredTarget;
+  }
+  protected set target(target: T) {
+    this.configuredTarget = target;
+  }
   protected projectRoot: string;
   protected logger: Logger;
   protected stateManager: StateManager;
   protected currentProcess?: ChildProcess;
 
   constructor(target: T, projectRoot: string, logger: Logger, stateManager: StateManager) {
-    this.target = target;
+    this.configuredTarget = target;
     this.projectRoot = projectRoot;
     this.logger = logger;
     this.stateManager = stateManager;
@@ -57,6 +66,20 @@ export abstract class BaseBuilder<T extends Target = Target> {
   }
 
   public async build(changedFiles: string[], options: BuildOptions = {}): Promise<BuildStatus> {
+    const target = this.configuredTarget;
+    return this.buildContext.run(target, async () => {
+      return recordBuildTarget(await this.buildCurrentTarget(changedFiles, options), target);
+    });
+  }
+
+  public updateTarget(target: T): void {
+    this.configuredTarget = target;
+  }
+
+  private async buildCurrentTarget(
+    changedFiles: string[],
+    options: BuildOptions,
+  ): Promise<BuildStatus> {
     // Format file list for logging
     const fileListText = this.formatChangedFiles(changedFiles);
     this.logger.info(
@@ -115,6 +138,7 @@ export abstract class BaseBuilder<T extends Target = Target> {
 
       // Update app info if available
       const outputInfo = this.getOutputInfo();
+      recordBuildOutput(successStatus, outputInfo);
       if (outputInfo) {
         await this.stateManager.updateAppInfo(this.target.name, {
           outputPath: outputInfo,

--- a/src/core/build-context.ts
+++ b/src/core/build-context.ts
@@ -1,0 +1,25 @@
+import type { BuildStatus, Target } from "../types.js";
+
+// Keep launch configuration with the result without persisting environment values in state.
+const buildTargets = new WeakMap<BuildStatus, Target>();
+const buildOutputs = new WeakMap<BuildStatus, string | undefined>();
+
+export function recordBuildOutput(result: BuildStatus, output: string | undefined): void {
+  buildOutputs.set(result, output);
+}
+
+export function outputForBuild(
+  result: BuildStatus,
+  fallback: () => string | undefined,
+): string | undefined {
+  return buildOutputs.has(result) ? buildOutputs.get(result) : fallback();
+}
+
+export function recordBuildTarget(result: BuildStatus, target: Target): BuildStatus {
+  buildTargets.set(result, target);
+  return result;
+}
+
+export function targetForBuild(result: BuildStatus, requestedTarget: Target): Target {
+  return buildTargets.get(result) ?? requestedTarget;
+}

--- a/src/core/build-coordinator.ts
+++ b/src/core/build-coordinator.ts
@@ -5,6 +5,7 @@ import type { Target } from "../types.js";
 import { BuildStatusManager } from "../utils/build-status-manager.js";
 import { FileSystemUtils } from "../utils/filesystem.js";
 import type { TargetState } from "./target-state.js";
+import { outputForBuild, targetForBuild } from "./build-context.js";
 
 interface BuildCoordinatorDeps {
   projectRoot: string;
@@ -62,6 +63,8 @@ export class BuildCoordinator {
   ): Promise<void> {
     const state = targetStates.get(targetName);
     if (!state) return;
+    const requestedTarget = state.target;
+    const builder = state.builder;
 
     const changedFiles = Array.from(state.pendingFiles);
     state.pendingFiles.clear();
@@ -75,7 +78,7 @@ export class BuildCoordinator {
         // eslint-disable-next-line no-console
         console.log(`coordinator build start ${targetName}`);
       }
-      const buildPromise = state.builder.build(changedFiles, buildOptions);
+      const buildPromise = builder.build(changedFiles, buildOptions);
       const maybeVi = (
         globalThis as {
           vi?: { runAllTimersAsync?: () => Promise<void>; isFakeTimers?: () => boolean };
@@ -85,6 +88,7 @@ export class BuildCoordinator {
         await maybeVi.runAllTimersAsync();
       }
       const status = await buildPromise;
+      if (targetStates.get(targetName) !== state || state.builder !== builder) return;
       if (process.env.VITEST && process.env.DEBUG_WAITS) {
         // eslint-disable-next-line no-console
         console.log("coordinator status", status.status, status.errorSummary ?? status.error);
@@ -97,7 +101,10 @@ export class BuildCoordinator {
 
       if (state.runner) {
         if (BuildStatusManager.isSuccess(status)) {
-          await state.runner.onBuildSuccess();
+          const builtTarget = targetForBuild(status, requestedTarget);
+          if (builtTarget.type === "executable") {
+            await state.runner.onBuildSuccess(builtTarget);
+          }
         } else if (BuildStatusManager.isFailure(status)) {
           state.runner.onBuildFailure(status);
         }
@@ -142,7 +149,7 @@ export class BuildCoordinator {
                 ?.calls,
             });
           }
-          const outputInfo = state.builder.getOutputInfo();
+          const outputInfo = outputForBuild(status, () => state.builder.getOutputInfo());
           const message = BuildStatusManager.formatNotificationMessage(status, outputInfo);
           for (const notifier of notifierSet) {
             await notifier.notifyBuildComplete(`${targetName} Built`, message, state.target.icon);
@@ -237,6 +244,7 @@ export class BuildCoordinator {
         this.lastNotified.set(targetName, dedupeKey);
       }
     } catch (error) {
+      if (targetStates.get(targetName) !== state || state.builder !== builder) return;
       const logMessage = error instanceof Error ? error.toString() : String(error);
       const notifyMessage = error instanceof Error ? error.message : String(error);
       this.logger.error(`Build failed for ${targetName}: ${logMessage}`);

--- a/src/core/target-lifecycle.ts
+++ b/src/core/target-lifecycle.ts
@@ -63,7 +63,7 @@ export class TargetLifecycleManager {
       }
 
       const runner =
-        target.type === "executable" && target.autoRun?.enabled
+        target.type === "executable"
           ? new ExecutableRunner(target as ExecutableTarget, {
               projectRoot: this.projectRoot,
               logger: this.logger,
@@ -145,36 +145,64 @@ export class TargetLifecycleManager {
   public async updateTargets(
     modifications: Array<{ name: string; newTarget: Target }>,
     buildQueue?: IntelligentBuildQueue,
+    targetStates = this.targetStates,
   ): Promise<void> {
     for (const mod of modifications) {
-      if (mod.newTarget.type !== "executable") {
+      const previous = targetStates.get(mod.name);
+      const typeChanged = previous && previous.target.type !== mod.newTarget.type;
+      if (mod.newTarget.type !== "executable" && !typeChanged) {
         this.logger.info(`ℹ️ Skipping non-executable target update: ${mod.name}`);
         continue;
       }
       this.logger.info(`♻️ Updating target: ${mod.name}`);
-      const previous = this.targetStates.get(mod.name);
-      const builder = previous?.builder
-        ? previous.builder
-        : this.builderFactory.createBuilder(
-            mod.newTarget,
-            this.projectRoot,
-            this.logger,
-            this.stateManager,
-          );
-      const runner = previous?.runner
-        ? previous.runner
-        : new ExecutableRunner(mod.newTarget as ExecutableTarget, {
-            projectRoot: this.projectRoot,
-            logger: this.logger,
-          });
-      this.targetStates.set(mod.name, {
+      const builder =
+        previous?.builder && !typeChanged
+          ? previous.builder
+          : this.builderFactory.createBuilder(
+              mod.newTarget,
+              this.projectRoot,
+              this.logger,
+              this.stateManager,
+            );
+      if (typeChanged) await builder.validate();
+      const runner =
+        mod.newTarget.type === "executable"
+          ? (!typeChanged && previous?.runner) ||
+            new ExecutableRunner(mod.newTarget, {
+              projectRoot: this.projectRoot,
+              logger: this.logger,
+            })
+          : undefined;
+      const postBuildRunner = typeChanged
+        ? mod.newTarget.postBuild?.length
+          ? new PostBuildRunner({
+              targetName: mod.name,
+              hooks: mod.newTarget.postBuild,
+              projectRoot: this.projectRoot,
+              stateManager: this.stateManager,
+              logger: this.logger,
+            })
+          : undefined
+        : previous?.postBuildRunner;
+      if (typeChanged) {
+        await previous.runner?.stop();
+        await previous.postBuildRunner?.stop();
+        previous.builder.stop();
+      } else {
+        previous?.builder.updateTarget(mod.newTarget);
+        if (mod.newTarget.type === "executable") {
+          await previous?.runner?.updateTarget(mod.newTarget);
+        }
+      }
+      const updatedState = {
         target: mod.newTarget,
         builder,
         watching: previous?.watching ?? false,
         pendingFiles: previous?.pendingFiles ?? new Set(),
         runner,
-        postBuildRunner: previous?.postBuildRunner,
-      });
+        postBuildRunner,
+      };
+      targetStates.set(mod.name, Object.assign(previous ?? {}, updatedState));
 
       if (buildQueue) {
         buildQueue.registerTarget(mod.newTarget, builder);

--- a/src/core/watch-service.ts
+++ b/src/core/watch-service.ts
@@ -20,7 +20,7 @@ interface WatchServiceDeps {
  */
 export class WatchService {
   private readonly projectRoot: string;
-  private readonly config: PoltergeistConfig;
+  private config: PoltergeistConfig;
   private readonly logger: Logger;
   private watchman?: IWatchmanClient;
   private readonly watchmanConfigManager: IWatchmanConfigManager;
@@ -131,10 +131,28 @@ export class WatchService {
     this.watchman = undefined;
   }
 
-  public async refreshTargets(targetStates: Map<string, TargetState>): Promise<void> {
+  public async refreshTargets(
+    targetStates: Map<string, TargetState>,
+    config = this.config,
+  ): Promise<void> {
     if (!this.watchman) return;
-    await this.unsubscribeAll();
+    this.config = config;
+    const previous = [...this.subscriptions.keys()];
+    const wanted = new Set(["poltergeist_config"]);
+    for (const state of targetStates.values()) {
+      for (const pattern of state.target.watchPaths) {
+        const normalized = this.watchmanConfigManager.normalizeWatchPattern(pattern);
+        wanted.add(`poltergeist_${normalized.replace(/[^a-zA-Z0-9]/g, "_")}`);
+      }
+    }
+    // Watchman replaces matching names atomically; keep old watches until replacements exist.
     await this.subscribeTargets(targetStates);
+    for (const name of previous) {
+      if (!wanted.has(name)) {
+        await this.watchman.unsubscribe(name);
+        this.subscriptions.delete(name);
+      }
+    }
   }
 
   public async unsubscribeTargets(targetNames: string[]): Promise<void> {
@@ -142,10 +160,11 @@ export class WatchService {
     const toRemove: string[] = [];
 
     for (const [subscription, targets] of this.subscriptions.entries()) {
+      if (subscription === "poltergeist_config") continue;
       for (const target of targetNames) {
         targets.delete(target);
       }
-      if (targets.size === 0 || subscription === "poltergeist_config") {
+      if (targets.size === 0) {
         toRemove.push(subscription);
       }
     }

--- a/src/poltergeist.ts
+++ b/src/poltergeist.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { IntelligentBuildQueue } from "./build-queue.js";
+import type { BaseBuilder } from "./builders/index.js";
 import { BuildCoordinator } from "./core/build-coordinator.js";
 import { ConfigReloadOrchestrator } from "./core/config-reload-orchestrator.js";
 import { DebouncedBuildScheduler } from "./core/debounced-build-scheduler.js";
@@ -21,6 +22,7 @@ import { BuildNotifier } from "./notifier.js";
 import { PostBuildRunner } from "./post-build/post-build-runner.js";
 import { PriorityEngine } from "./priority-engine.js";
 import { ExecutableRunner } from "./runners/executable-runner.js";
+import { outputForBuild, targetForBuild } from "./core/build-context.js";
 import { isPoltergeistState, type PoltergeistState, StateManager } from "./state.js";
 import type {
   BuildRequest,
@@ -68,6 +70,7 @@ export class Poltergeist {
   > = [];
   private watchService?: WatchService;
   private buildCoordinator?: BuildCoordinator;
+  private reloadTail: Promise<void> = Promise.resolve();
   private statusPresenter: StatusPresenter;
   private debouncedScheduler: DebouncedBuildScheduler;
   private lifecycle: TargetLifecycleManager;
@@ -170,7 +173,7 @@ export class Poltergeist {
           if (last) {
             const message = BuildStatusManager.formatNotificationMessage(
               last,
-              state.builder.getOutputInfo?.(),
+              outputForBuild(last, () => state.builder.getOutputInfo?.()),
             );
             await this.deps.notifier.notifyBuildComplete(
               `${name} Built`,
@@ -329,7 +332,7 @@ export class Poltergeist {
         this.priorityEngine,
         this.notifier,
         async (result: BuildStatus, request: BuildRequest) => {
-          await this.handleQueuedBuildResult(result, { target: request.target });
+          await this.handleQueuedBuildResult(result, request);
           for (const hook of this.buildQueueHooks) {
             await hook(result, request);
           }
@@ -344,7 +347,7 @@ export class Poltergeist {
       this.priorityEngine,
       this.notifier,
       async (result: BuildStatus, request: BuildRequest) => {
-        await this.handleQueuedBuildResult(result, { target: request.target });
+        await this.handleQueuedBuildResult(result, request);
         for (const hook of this.buildQueueHooks) {
           await hook(result, request);
         }
@@ -543,6 +546,11 @@ export class Poltergeist {
     const configChanged = files.some((f) => f.name === "poltergeist.config.json" && f.exists);
     if (!configChanged || !this.configPath) return;
 
+    this.reloadTail = this.reloadTail.then(() => this.reloadConfiguration());
+    await this.reloadTail;
+  }
+
+  private async reloadConfiguration(): Promise<void> {
     this.logger.info("🔄 Configuration file changed, reloading...");
 
     try {
@@ -603,11 +611,12 @@ export class Poltergeist {
 
   private async handleQueuedBuildResult(
     result: BuildStatus,
-    _request: { target: Target },
+    _request: { target: Target; builder?: BaseBuilder },
   ): Promise<void> {
     const targetName = result.targetName ?? _request.target.name;
     const state = this.targetStates.get(targetName);
     if (!state) return;
+    if (_request.builder && _request.builder !== state.builder) return;
 
     state.lastBuild = result;
     state.pendingFiles.clear();
@@ -618,7 +627,10 @@ export class Poltergeist {
 
     if (state.runner) {
       if (BuildStatusManager.isSuccess(result)) {
-        await state.runner.onBuildSuccess();
+        const builtTarget = targetForBuild(result, _request.target);
+        if (builtTarget.type === "executable") {
+          await state.runner.onBuildSuccess(builtTarget);
+        }
       } else if (BuildStatusManager.isFailure(result)) {
         state.runner.onBuildFailure(result);
       }
@@ -633,7 +645,7 @@ export class Poltergeist {
       );
       const message = BuildStatusManager.formatNotificationMessage(
         result,
-        state.builder.getOutputInfo?.(),
+        outputForBuild(result, () => state.builder.getOutputInfo?.()),
       );
       for (const notifier of notifierSet) {
         await notifier.notifyBuildComplete(`${targetName} Built`, message, state.target.icon);
@@ -735,6 +747,12 @@ export class Poltergeist {
     for (const name of changes.targetsRemoved) {
       try {
         this.logger.info(`➖ Removing target: ${name}`);
+        const state = this.targetStates.get(name);
+        if (state?.buildTimer) clearTimeout(state.buildTimer);
+        this.buildQueue?.unregisterTarget(name);
+        await state?.runner?.stop();
+        await state?.postBuildRunner?.stop();
+        state?.builder.stop();
         this.targetStates.delete(name);
         await this.stateManager.removeState(name);
       } catch (error) {
@@ -796,41 +814,7 @@ export class Poltergeist {
       }
     }
 
-    // Handle target modifications (simplified: replace definitions)
-    for (const mod of changes.targetsModified) {
-      if (mod.newTarget.type !== "executable") {
-        this.logger.info(`ℹ️ Skipping non-executable target update: ${mod.name}`);
-        continue;
-      }
-      this.logger.info(`♻️ Updating target: ${mod.name}`);
-      const previous = this.targetStates.get(mod.name);
-      const builder = previous?.builder
-        ? previous.builder
-        : this.builderFactory.createBuilder(
-            mod.newTarget,
-            this.projectRoot,
-            this.logger,
-            this.stateManager,
-          );
-      const runner = previous?.runner
-        ? previous.runner
-        : new ExecutableRunner(mod.newTarget as ExecutableTarget, {
-            projectRoot: this.projectRoot,
-            logger: this.logger,
-          });
-      this.targetStates.set(mod.name, {
-        target: mod.newTarget,
-        builder,
-        watching: previous?.watching ?? false,
-        pendingFiles: previous?.pendingFiles ?? new Set(),
-        runner,
-        postBuildRunner: previous?.postBuildRunner,
-      });
-
-      if (this.buildQueue) {
-        this.buildQueue.registerTarget(mod.newTarget, builder);
-      }
-    }
+    await this.lifecycle.updateTargets(changes.targetsModified, this.buildQueue, this.targetStates);
 
     // Apply other config changes
     if (changes.notificationsChanged) {
@@ -892,7 +876,7 @@ export class Poltergeist {
       if (changes.targetsRemoved.length > 0) {
         await this.watchService.unsubscribeTargets(changes.targetsRemoved);
       }
-      await this.watchService.refreshTargets(this.targetStates);
+      await this.watchService.refreshTargets(this.targetStates, newConfig);
     }
   }
 

--- a/src/runners/executable-runner.ts
+++ b/src/runners/executable-runner.ts
@@ -8,37 +8,52 @@ export interface ExecutableRunnerOptions {
   logger: Logger;
 }
 
+interface PendingLaunch {
+  target: ExecutableTarget;
+  readyAt: number;
+}
+
 export class ExecutableRunner {
   private child: ChildProcess | null = null;
-  private pendingRestart = false;
+  private pendingLaunch?: PendingLaunch;
+  private restarting = false;
   private restartTimer: NodeJS.Timeout | null = null;
-  private readonly restartSignal: NodeJS.Signals;
-  private readonly restartDelay: number;
-  private readonly args: string[];
-  private readonly env?: Record<string, string>;
-  private readonly customCommand?: string;
   private shuttingDown = false;
 
   constructor(
-    private readonly target: ExecutableTarget,
+    private target: ExecutableTarget,
     private readonly options: ExecutableRunnerOptions,
-  ) {
-    const cfg = target.autoRun ?? {};
-    const restartSignal = cfg.restartSignal as NodeJS.Signals | undefined;
-    this.restartSignal = restartSignal ?? "SIGINT";
-    this.restartDelay = Math.max(0, cfg.restartDelayMs ?? 250);
-    this.args = Array.isArray(cfg.args) ? cfg.args : [];
-    this.env = cfg.env;
-    this.customCommand = cfg.command;
+  ) {}
+
+  public async updateTarget(target: ExecutableTarget): Promise<void> {
+    this.target = target;
+    if (!target.autoRun?.enabled) {
+      this.cancelPendingLaunch();
+      await this.stopChild("SIGTERM");
+    }
   }
 
-  public async onBuildSuccess(): Promise<void> {
-    if (!this.target.autoRun?.enabled) {
+  public async onBuildSuccess(builtTarget = this.target): Promise<void> {
+    if (!this.target.autoRun?.enabled || !builtTarget.autoRun?.enabled || this.shuttingDown) {
       return;
     }
-    if (!this.child) {
-      await this.launch("initial-success");
+    if (!this.child && !this.restarting && !this.pendingLaunch) {
+      this.launch("initial-success", builtTarget);
       return;
+    }
+    // Keep ordinary rebuild coalescing, but give each new configuration its own deadline.
+    const previous = this.pendingLaunch;
+    this.pendingLaunch = {
+      target: builtTarget,
+      readyAt:
+        previous?.target === builtTarget
+          ? previous.readyAt
+          : performance.now() + Math.max(0, builtTarget.autoRun?.restartDelayMs ?? 250),
+    };
+    if (this.restarting) return;
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
     }
     this.scheduleRestart();
   }
@@ -53,42 +68,57 @@ export class ExecutableRunner {
   }
 
   public async stop(): Promise<void> {
+    this.shuttingDown = true;
+    this.cancelPendingLaunch();
+    await this.stopChild("SIGTERM");
+  }
+
+  private cancelPendingLaunch(): void {
     if (this.restartTimer) {
       clearTimeout(this.restartTimer);
       this.restartTimer = null;
     }
-    this.pendingRestart = false;
-    this.shuttingDown = true;
-    await this.stopChild("SIGTERM");
+    this.pendingLaunch = undefined;
   }
 
   private scheduleRestart(): void {
-    if (this.pendingRestart) {
-      return;
-    }
-    this.pendingRestart = true;
-    if (this.restartDelay === 0) {
+    if (!this.pendingLaunch) return;
+    const restartDelay = Math.max(0, this.pendingLaunch.readyAt - performance.now());
+    if (restartDelay === 0) {
       void this.performRestart();
       return;
     }
     this.restartTimer = setTimeout(() => {
       void this.performRestart();
-    }, this.restartDelay);
+    }, restartDelay);
   }
 
   private async performRestart(): Promise<void> {
-    this.pendingRestart = false;
     this.restartTimer = null;
-    await this.stopChild(this.restartSignal);
-    await this.launch("rebuild");
+    const pending = this.pendingLaunch;
+    if (!pending || this.restarting) return;
+    this.restarting = true;
+    try {
+      await this.stopChild((pending.target.autoRun?.restartSignal as NodeJS.Signals) ?? "SIGINT");
+    } finally {
+      this.restarting = false;
+    }
+    const latest = this.pendingLaunch;
+    if (!latest) return;
+    if (latest.readyAt > performance.now()) {
+      this.scheduleRestart();
+      return;
+    }
+    this.pendingLaunch = undefined;
+    this.launch("rebuild", latest.target);
   }
 
-  private async launch(reason: string): Promise<void> {
+  private launch(reason: string, target: ExecutableTarget): void {
     if (!this.target.autoRun?.enabled || this.shuttingDown) {
       return;
     }
     try {
-      const launchInfo = this.resolveLaunchInfo();
+      const launchInfo = this.resolveLaunchInfo(target);
       this.options.logger.info(
         `[${this.target.name}] Auto-run starting (${reason}) · ${launchInfo.command} ${launchInfo.commandArgs.join(" ")}`,
       );
@@ -96,16 +126,12 @@ export class ExecutableRunner {
       this.child = spawn(launchInfo.command, launchInfo.commandArgs, {
         cwd: this.options.projectRoot,
         stdio: "inherit",
-        env: this.env ? { ...process.env, ...this.env } : process.env,
+        env: target.autoRun?.env ? { ...process.env, ...target.autoRun.env } : process.env,
       });
 
-      this.child.on("exit", (code, signal) => {
-        if (this.restartTimer) {
-          clearTimeout(this.restartTimer);
-          this.restartTimer = null;
-        }
-        this.pendingRestart = false;
-        this.child = null;
+      const child = this.child;
+      child.on("exit", (code, signal) => {
+        if (this.child === child) this.child = null;
         if (!this.shuttingDown) {
           const status = signal ? `signal ${signal}` : `code ${code}`;
           this.options.logger.info(
@@ -136,15 +162,16 @@ export class ExecutableRunner {
     }
   }
 
-  private resolveLaunchInfo() {
-    if (this.customCommand) {
+  private resolveLaunchInfo(target: ExecutableTarget) {
+    const args = target.autoRun?.args ?? [];
+    if (target.autoRun?.command) {
       return {
-        command: this.customCommand,
-        commandArgs: this.args,
-        binaryPath: this.customCommand,
+        command: target.autoRun.command,
+        commandArgs: args,
+        binaryPath: target.autoRun.command,
       };
     }
-    return prepareLaunchInfo(this.target, this.options.projectRoot, this.args);
+    return prepareLaunchInfo(target, this.options.projectRoot, args);
   }
 
   private stopChild(signal: NodeJS.Signals): Promise<void> {
@@ -164,7 +191,7 @@ export class ExecutableRunner {
       };
 
       const forceKillTimer = setTimeout(() => {
-        if (!child.killed) {
+        if (child.exitCode === null && child.signalCode === null) {
           child.kill("SIGKILL");
         }
       }, 5000);

--- a/src/runners/executable-runner.ts
+++ b/src/runners/executable-runner.ts
@@ -13,6 +13,8 @@ interface PendingLaunch {
   readyAt: number;
 }
 
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
 export class ExecutableRunner {
   private child: ChildProcess | null = null;
   private pendingLaunch?: PendingLaunch;
@@ -83,7 +85,11 @@ export class ExecutableRunner {
 
   private scheduleRestart(): void {
     if (!this.pendingLaunch) return;
-    const restartDelay = Math.max(0, this.pendingLaunch.readyAt - performance.now());
+    // Node turns larger timeouts into 1 ms timers; preserve long delays in bounded chunks.
+    const restartDelay = Math.min(
+      MAX_TIMER_DELAY_MS,
+      Math.max(0, this.pendingLaunch.readyAt - performance.now()),
+    );
     if (restartDelay === 0) {
       void this.performRestart();
       return;
@@ -97,6 +103,10 @@ export class ExecutableRunner {
     this.restartTimer = null;
     const pending = this.pendingLaunch;
     if (!pending || this.restarting) return;
+    if (pending.readyAt > performance.now()) {
+      this.scheduleRestart();
+      return;
+    }
     this.restarting = true;
     try {
       await this.stopChild((pending.target.autoRun?.restartSignal as NodeJS.Signals) ?? "SIGINT");

--- a/src/watchman.ts
+++ b/src/watchman.ts
@@ -28,6 +28,7 @@ export class WatchmanClient extends EventEmitter {
   private watchRoot?: string;
   private logger: Logger;
   private subscriptions: Map<string, string> = new Map();
+  private subscriptionHandlers = new Map<string, (data: unknown) => void>();
   private clock?: string; // Track the clock for incremental updates
 
   constructor(logger: Logger) {
@@ -258,6 +259,9 @@ export class WatchmanClient extends EventEmitter {
           }
 
           this.logger.debug(`Subscription response: ${JSON.stringify(resp)}`);
+          const previousHandler = this.subscriptionHandlers.get(subscriptionName);
+          if (previousHandler) this.client.removeListener("subscription", previousHandler);
+          this.subscriptionHandlers.set(subscriptionName, handler);
           this.subscriptions.set(subscriptionName, projectRoot);
           this.logger.info(`Subscription created: ${subscriptionName}`);
           this.logger.debug(
@@ -282,6 +286,9 @@ export class WatchmanClient extends EventEmitter {
             this.logger.warn(`Failed to unsubscribe ${subscriptionName}: ${error.message}`);
           }
           this.subscriptions.delete(subscriptionName);
+          const handler = this.subscriptionHandlers.get(subscriptionName);
+          if (handler) this.client.removeListener("subscription", handler);
+          this.subscriptionHandlers.delete(subscriptionName);
           resolve();
         },
       );

--- a/test/build-queue.test.ts
+++ b/test/build-queue.test.ts
@@ -585,6 +585,87 @@ describe("IntelligentBuildQueue", () => {
   });
 
   describe("Error Handling", () => {
+    it("retries with the current target and builder after a configuration reload", async () => {
+      const original = { ...targets[0], maxRetries: 1 };
+      const failedBuilder = createMockBuilder("frontend");
+      vi.mocked(failedBuilder.build).mockResolvedValue({
+        status: "failure",
+        targetName: "frontend",
+        timestamp: "test",
+        error: "old command failed",
+      });
+      buildQueue.registerTarget(original, failedBuilder);
+      await buildQueue.queueTargetBuild(original);
+      await vi.advanceTimersByTimeAsync(0);
+      const corrected = { ...original, buildCommand: "corrected build" };
+      const correctedBuilder = createMockBuilder("frontend");
+      vi.mocked(correctedBuilder.build).mockResolvedValue({
+        status: "success",
+        targetName: "frontend",
+        timestamp: "test",
+      });
+      buildQueue.registerTarget(corrected, correctedBuilder);
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(failedBuilder.build).toHaveBeenCalledTimes(1);
+      expect(correctedBuilder.build).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry a target that was unregistered during backoff", async () => {
+      const target = { ...targets[0], maxRetries: 1 };
+      const builder = createMockBuilder("frontend");
+      vi.mocked(builder.build).mockResolvedValue({
+        status: "failure",
+        targetName: "frontend",
+        timestamp: "test",
+        error: "failed",
+      });
+      buildQueue.registerTarget(target, builder);
+      await buildQueue.queueTargetBuild(target);
+      await vi.advanceTimersByTimeAsync(0);
+      buildQueue.unregisterTarget(target.name);
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(builder.build).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not transfer a removed target's retry to a new registration with the same name", async () => {
+      const target = { ...targets[0], maxRetries: 1 };
+      const builder = createMockBuilder("frontend");
+      vi.mocked(builder.build).mockResolvedValue({
+        status: "failure",
+        targetName: "frontend",
+        timestamp: "test",
+        error: "failed",
+      });
+      buildQueue.registerTarget(target, builder);
+      await buildQueue.queueTargetBuild(target);
+      await vi.advanceTimersByTimeAsync(0);
+      buildQueue.unregisterTarget(target.name);
+      const replacement = createMockBuilder("frontend");
+      buildQueue.registerTarget({ ...target }, replacement);
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(replacement.build).not.toHaveBeenCalled();
+    });
+
+    it("keeps retry ownership when a completion callback removes and re-adds a target", async () => {
+      const target = { ...targets[0], maxRetries: 1 };
+      const original = createMockBuilder("frontend");
+      const replacement = createMockBuilder("frontend");
+      vi.mocked(original.build).mockResolvedValue({
+        status: "failure",
+        targetName: "frontend",
+        timestamp: "test",
+        error: "failed",
+      });
+      const queue = new IntelligentBuildQueue(config, logger, priorityEngine, undefined, () => {
+        queue.unregisterTarget(target.name);
+        queue.registerTarget({ ...target }, replacement);
+      });
+      queue.registerTarget(target, original);
+      await queue.queueTargetBuild(target);
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(replacement.build).not.toHaveBeenCalled();
+    });
+
     it("should handle missing builders gracefully", async () => {
       // Don't register any builders
       await buildQueue.onFileChanged(["frontend/src/app.ts"], [targets[0]]);

--- a/test/config-reload-lifecycle.test.ts
+++ b/test/config-reload-lifecycle.test.ts
@@ -1,0 +1,507 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BaseBuilder } from "../src/builders/base-builder.js";
+import { targetForBuild } from "../src/core/build-context.js";
+import { BuildCoordinator } from "../src/core/build-coordinator.js";
+import { TargetLifecycleManager } from "../src/core/target-lifecycle.js";
+import type { TargetState } from "../src/core/target-state.js";
+import type { BuildNotifier } from "../src/notifier.js";
+import { WatchService } from "../src/core/watch-service.js";
+import { Poltergeist } from "../src/poltergeist.js";
+import { ExecutableRunner } from "../src/runners/executable-runner.js";
+import type { StateManager } from "../src/state.js";
+import type { ExecutableTarget, PoltergeistConfig, Target } from "../src/types.js";
+import { detectConfigChanges } from "../src/utils/config-diff.js";
+import {
+  createMockBuilder,
+  createMockDependencies,
+  createMockLogger,
+  createMockStateManager,
+} from "./helpers.js";
+
+vi.mock("child_process", async (original) => ({
+  ...(await original<typeof import("child_process")>()),
+  spawn: vi.fn(),
+}));
+const { spawn } = await import("child_process");
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+const target = (generation: string): ExecutableTarget => ({
+  name: "app",
+  type: "executable",
+  enabled: true,
+  buildCommand: generation,
+  outputPath: `out-${generation}`,
+  watchPaths: [`${generation}/**/*.ts`],
+  autoRun: {
+    enabled: true,
+    command: `run-${generation}`,
+    args: [generation],
+    env: { GENERATION: generation },
+    restartDelayMs: 100,
+  },
+});
+
+class RecordingBuilder extends BaseBuilder<ExecutableTarget> {
+  gate = Promise.resolve();
+  stages: string[] = [];
+  async validate() {}
+  getOutputInfo(): string | undefined {
+    return undefined;
+  }
+  protected getGitHash() {
+    return "test";
+  }
+  protected async executeBuild() {
+    this.stages.push(this.target.buildCommand);
+    await this.gate;
+  }
+  protected async postBuild() {
+    this.stages.push(this.target.outputPath);
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("configuration reload lifecycle", () => {
+  it("keeps the existing target alive if its replacement cannot be created", async () => {
+    const deps = createMockDependencies();
+    const builder = createMockBuilder("app");
+    const factory = vi
+      .fn()
+      .mockReturnValueOnce(builder)
+      .mockImplementationOnce(() => {
+        throw new Error("unsupported target");
+      });
+    const manager = new TargetLifecycleManager({
+      projectRoot: "/project",
+      logger: createMockLogger(),
+      stateManager: deps.stateManager,
+      builderFactory: { createBuilder: factory },
+    });
+    await manager.initTargets([target("A")]);
+    const state = manager.getTargetStates().get("app")!;
+    const stop = vi.spyOn(state.runner!, "stop");
+    const library: Target = {
+      name: "app",
+      type: "library",
+      enabled: true,
+      buildCommand: "build",
+      outputPath: "lib",
+      libraryType: "static",
+      watchPaths: [],
+    };
+    await expect(manager.updateTargets([{ name: "app", newTarget: library }])).rejects.toThrow(
+      "unsupported target",
+    );
+    expect(builder.stop).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
+    expect(state.target.type).toBe("executable");
+  });
+
+  it.each([false, true])(
+    "recreates a builder when its target type changes (reverse=%s)",
+    async (reverse) => {
+      const executable = target("A");
+      const library: Target = {
+        name: "app",
+        type: "library",
+        enabled: true,
+        buildCommand: "library build",
+        outputPath: "out-lib",
+        libraryType: "static",
+        watchPaths: ["src/**/*.ts"],
+      };
+      const [before, after] = reverse ? [library, executable] : [executable, library];
+      const deps = createMockDependencies();
+      const factory = vi.fn(() => createMockBuilder("app"));
+      const manager = new TargetLifecycleManager({
+        projectRoot: "/project",
+        logger: createMockLogger(),
+        stateManager: deps.stateManager,
+        builderFactory: { createBuilder: factory },
+      });
+      await manager.initTargets([before]);
+      const previousBuilder = manager.getTargetStates().get("app")!.builder;
+      await manager.updateTargets([{ name: "app", newTarget: after }]);
+      expect(previousBuilder.stop).toHaveBeenCalledOnce();
+      expect(factory).toHaveBeenCalledTimes(2);
+      expect(manager.getTargetStates().get("app")!.builder).not.toBe(previousBuilder);
+      expect(manager.getTargetStates().get("app")!.target).toBe(after);
+      expect(Boolean(manager.getTargetStates().get("app")!.runner)).toBe(
+        after.type === "executable",
+      );
+    },
+  );
+
+  it("reports the output produced by an active build after the configured path changes", async () => {
+    class OutputBuilder extends RecordingBuilder {
+      getOutputInfo() {
+        return this.target.outputPath;
+      }
+    }
+    const a = target("A");
+    const b = target("B");
+    const logger = createMockLogger();
+    const stateManager = Object.assign(createMockStateManager(), {
+      updateAppInfo: vi.fn().mockResolvedValue(undefined),
+    });
+    const builder = new OutputBuilder(
+      a,
+      "/project",
+      logger,
+      stateManager as unknown as StateManager,
+    );
+    const gate = deferred();
+    builder.gate = gate.promise;
+    const state: TargetState = { target: a, builder, watching: true, pendingFiles: new Set() };
+    const notifyBuildComplete = vi.fn();
+    const coordinator = new BuildCoordinator({
+      projectRoot: "/project",
+      logger,
+      stateManager,
+      notifier: { notifyBuildComplete } as unknown as BuildNotifier,
+    });
+    const build = coordinator.buildTarget("app", new Map([["app", state]]));
+    builder.updateTarget(b);
+    state.target = b;
+    gate.resolve();
+    await build;
+    expect(notifyBuildComplete).toHaveBeenCalledWith(
+      "app Built",
+      expect.stringContaining("out-A"),
+      undefined,
+    );
+  });
+
+  it("keeps all active build stages and results on their producing target", async () => {
+    const a = target("A");
+    const b = target("B");
+    const builder = new RecordingBuilder(
+      a,
+      "/project",
+      createMockLogger(),
+      createMockStateManager() as StateManager,
+    );
+    const gate = deferred();
+    builder.gate = gate.promise;
+    const first = builder.build([]);
+    const second = builder.build([]);
+    builder.updateTarget(b);
+    const third = builder.build([]);
+    gate.resolve();
+    const results = await Promise.all([first, second]);
+    expect(targetForBuild(await third, a)).toBe(b);
+    expect(builder.stages).toEqual(["A", "A", "B", "out-A", "out-A", "out-B"]);
+    for (const result of results) expect(targetForBuild(result, b)).toBe(a);
+    const next = await builder.build([]);
+    expect(targetForBuild(next, a)).toBe(b);
+    expect(builder.stages.slice(-2)).toEqual(["B", "out-B"]);
+    expect(JSON.stringify(next)).not.toContain("GENERATION");
+  });
+
+  it("updates the retained builder through the production reload application", async () => {
+    const a = target("A");
+    const b = target("B");
+    const config: PoltergeistConfig = { version: "1.0", targets: [a] };
+    const deps = createMockDependencies();
+    const builder = new RecordingBuilder(
+      a,
+      "/project",
+      createMockLogger(),
+      deps.stateManager as StateManager,
+    );
+    deps.builderFactory.createBuilder = vi.fn().mockReturnValue(builder);
+    const app = new Poltergeist(config, "/project", createMockLogger(), deps);
+    await app.applyConfigChanges(config, {
+      ...detectConfigChanges(config, config),
+      targetsAdded: [a],
+    });
+    const next = { ...config, targets: [b] };
+    await app.applyConfigChanges(next, detectConfigChanges(config, next));
+    await builder.build([]);
+    expect(builder.stages).toEqual(["B", "out-B"]);
+  });
+
+  it("does not deliver an old builder's completion to its replacement runner", async () => {
+    const a = target("A");
+    const b = target("B");
+    const logger = createMockLogger();
+    const stateManager = createMockStateManager();
+    const builder = new RecordingBuilder(a, "/project", logger, stateManager as StateManager);
+    const gate = deferred();
+    builder.gate = gate.promise;
+    const state: TargetState = { target: a, builder, watching: true, pendingFiles: new Set() };
+    const states = new Map([["app", state]]);
+    const coordinator = new BuildCoordinator({ projectRoot: "/project", logger, stateManager });
+    const build = coordinator.buildTarget("app", states);
+    state.target = b;
+    state.builder = createMockBuilder("app");
+    state.runner = new ExecutableRunner(b, { projectRoot: "/project", logger });
+    const launch = vi.spyOn(state.runner, "onBuildSuccess").mockResolvedValue(undefined);
+    gate.resolve();
+    await build;
+    expect(launch).not.toHaveBeenCalled();
+    expect(state.lastBuild).toBeUndefined();
+  });
+
+  it("ignores queued completions owned by a retired builder", async () => {
+    const a = target("A");
+    const b = target("B");
+    const config: PoltergeistConfig = { version: "1.0", targets: [b] };
+    const app = new Poltergeist(config, "/project", createMockLogger(), createMockDependencies());
+    await app.applyConfigChanges(config, {
+      ...detectConfigChanges(config, config),
+      targetsAdded: [b],
+    });
+    const internal = app as unknown as {
+      targetStates: Map<string, TargetState>;
+      handleQueuedBuildResult: (
+        result: { status: string; timestamp: string; targetName: string },
+        request: { target: Target; builder: BaseBuilder },
+      ) => Promise<void>;
+    };
+    const state = internal.targetStates.get("app")!;
+    const launch = vi.spyOn(state.runner!, "onBuildSuccess").mockResolvedValue(undefined);
+    await internal.handleQueuedBuildResult(
+      { status: "success", timestamp: "test", targetName: "app" },
+      { target: a, builder: createMockBuilder("app") },
+    );
+    expect(launch).not.toHaveBeenCalled();
+    expect(state.lastBuild).toBeUndefined();
+  });
+
+  it("serializes load, diff, apply and commit and recovers after a failed reload", async () => {
+    const config: PoltergeistConfig = { version: "1.0", targets: [target("A")] };
+    const b = { ...config, targets: [target("B")] };
+    const c = { ...config, targets: [target("C")] };
+    const app = new Poltergeist(
+      config,
+      "/project",
+      createMockLogger(),
+      createMockDependencies(),
+      "/project/poltergeist.config.json",
+    );
+    const internal = app as unknown as {
+      configReload: { reloadConfig: ReturnType<typeof vi.fn> };
+      handleConfigChange: (files: { name: string; exists: boolean }[]) => Promise<void>;
+    };
+    const loader = vi
+      .fn()
+      .mockResolvedValueOnce({ config: b, changes: detectConfigChanges(config, b) })
+      .mockRejectedValueOnce(new Error("invalid config"))
+      .mockResolvedValueOnce({ config: c, changes: detectConfigChanges(b, c) });
+    internal.configReload = { reloadConfig: loader };
+    const gate = deferred();
+    vi.spyOn(app, "applyConfigChanges")
+      .mockImplementationOnce(() => gate.promise)
+      .mockResolvedValue(undefined);
+    const files = [{ name: "poltergeist.config.json", exists: true }];
+    const first = internal.handleConfigChange(files);
+    const second = internal.handleConfigChange(files);
+    await vi.waitFor(() => expect(app.applyConfigChanges).toHaveBeenCalledTimes(1));
+    expect(loader).toHaveBeenCalledTimes(1);
+    gate.resolve();
+    await Promise.all([first, second]);
+    await internal.handleConfigChange(files);
+    expect(loader.mock.calls.map(([current]) => current)).toEqual([config, b, b]);
+  });
+
+  it("retains the config subscription through repeated target refreshes and removals", async () => {
+    const deps = createMockDependencies();
+    const config: PoltergeistConfig = { version: "1.0", targets: [] };
+    const service = new WatchService({
+      projectRoot: "/project",
+      config,
+      logger: createMockLogger(),
+      watchman: deps.watchmanClient,
+      watchmanConfigManager: deps.watchmanConfigManager!,
+      onFilesChanged: vi.fn(),
+    });
+    await service.subscribeConfig("/project/poltergeist.config.json", vi.fn());
+    await service.refreshTargets(new Map(), config);
+    await service.unsubscribeTargets(["app"]);
+    await service.refreshTargets(new Map(), config);
+    expect(deps.watchmanClient?.unsubscribe).not.toHaveBeenCalledWith("poltergeist_config");
+    await service.stop();
+    expect(deps.watchmanClient?.unsubscribe).toHaveBeenCalledWith("poltergeist_config");
+  });
+});
+
+describe("artifact-owned restarts", () => {
+  function setup() {
+    vi.useFakeTimers();
+    const children: Array<
+      EventEmitter & {
+        exitCode: number | null;
+        signalCode: NodeJS.Signals | null;
+        killed: boolean;
+        kill: ReturnType<typeof vi.fn>;
+      }
+    > = [];
+    vi.mocked(spawn).mockImplementation(() => {
+      const child = Object.assign(new EventEmitter(), {
+        exitCode: null as number | null,
+        signalCode: null as NodeJS.Signals | null,
+        killed: false,
+        kill: vi.fn(),
+      });
+      child.kill.mockImplementation((signal: NodeJS.Signals) => {
+        child.killed = true;
+        child.signalCode = signal;
+        child.emit("exit", null, signal);
+        return true;
+      });
+      children.push(child);
+      return child as unknown as ChildProcess;
+    });
+    const runner = new ExecutableRunner(target("A"), {
+      projectRoot: "/project",
+      logger: createMockLogger(),
+    });
+    return { runner, children };
+  }
+
+  it("launches the newest successful artifact while a failed newer config cannot redirect it", async () => {
+    const { runner } = setup();
+    await runner.onBuildSuccess(target("A"));
+    await runner.onBuildSuccess(target("A"));
+    await runner.updateTarget(target("B"));
+    await runner.onBuildSuccess(target("B"));
+    await runner.updateTarget(target("C"));
+    runner.onBuildFailure({ status: "failure", timestamp: "test", error: "failed C" });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(vi.mocked(spawn).mock.calls.map(([command]) => command)).toEqual(["run-A", "run-B"]);
+    expect(spawn).toHaveBeenLastCalledWith(
+      "run-B",
+      ["B"],
+      expect.objectContaining({ env: expect.objectContaining({ GENERATION: "B" }) }),
+    );
+    await runner.stop();
+  });
+
+  it("keeps a successful target through asynchronous child shutdown", async () => {
+    const { runner, children } = setup();
+    await runner.onBuildSuccess(target("A"));
+    children[0].kill.mockReturnValue(true);
+    await runner.onBuildSuccess(target("A"));
+    await vi.advanceTimersByTimeAsync(100);
+    await runner.updateTarget(target("B"));
+    await runner.onBuildSuccess(target("B"));
+    children[0].emit("exit", 0, null);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(vi.mocked(spawn).mock.calls.map(([command]) => command)).toEqual(["run-A", "run-B"]);
+    await runner.stop();
+  });
+
+  it("uses the latest successful target's restart delay", async () => {
+    const { runner } = setup();
+    await runner.onBuildSuccess(target("A"));
+    await runner.onBuildSuccess(target("A"));
+    const b = target("B");
+    b.autoRun!.restartDelayMs = 1000;
+    await runner.updateTarget(b);
+    await runner.onBuildSuccess(b);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const c = target("C");
+    c.autoRun!.restartDelayMs = 0;
+    await runner.updateTarget(c);
+    await runner.onBuildSuccess(c);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.mocked(spawn).mock.calls.map(([command]) => command)).toEqual(["run-A", "run-C"]);
+    await runner.stop();
+  });
+
+  it("starts a fresh delay for a newer artifact even when the delay value is unchanged", async () => {
+    const { runner } = setup();
+    await runner.onBuildSuccess(target("A"));
+    await runner.onBuildSuccess(target("A"));
+    await vi.advanceTimersByTimeAsync(90);
+    await runner.updateTarget(target("B"));
+    await runner.onBuildSuccess(target("B"));
+    await vi.advanceTimersByTimeAsync(10);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(90);
+    expect(vi.mocked(spawn).mock.calls.map(([command]) => command)).toEqual(["run-A", "run-B"]);
+    await runner.stop();
+  });
+
+  it("preserves the existing coalesced deadline for repeated builds of the same configuration", async () => {
+    const { runner } = setup();
+    const a = target("A");
+    await runner.onBuildSuccess(a);
+    await runner.onBuildSuccess(a);
+    await vi.advanceTimersByTimeAsync(90);
+    await runner.onBuildSuccess(a);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(spawn).toHaveBeenCalledTimes(2);
+    await runner.stop();
+  });
+
+  it("does not strand a build success arriving as a restart finishes", async () => {
+    const { runner } = setup();
+    const createChild = vi.mocked(spawn).getMockImplementation()!;
+    const c = target("C");
+    c.autoRun!.restartDelayMs = 0;
+    vi.mocked(spawn).mockImplementation((command, args, options) => {
+      const child = createChild(command, args, options);
+      if (command === "run-B")
+        queueMicrotask(() => {
+          void runner.onBuildSuccess(c);
+        });
+      return child;
+    });
+    await runner.onBuildSuccess(target("A"));
+    await runner.updateTarget(target("B"));
+    await runner.onBuildSuccess(target("B"));
+    await vi.advanceTimersByTimeAsync(100);
+    expect(vi.mocked(spawn).mock.calls.map(([command]) => command)).toEqual([
+      "run-A",
+      "run-B",
+      "run-C",
+    ]);
+    await runner.stop();
+  });
+
+  it("cancels queued launches when disabled and can subsequently be re-enabled", async () => {
+    const { runner } = setup();
+    await runner.onBuildSuccess(target("A"));
+    await runner.onBuildSuccess(target("A"));
+    await runner.updateTarget({ ...target("B"), autoRun: { enabled: false } });
+    await vi.advanceTimersByTimeAsync(200);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    await runner.updateTarget(target("C"));
+    await runner.onBuildSuccess(target("C"));
+    expect(vi.mocked(spawn).mock.calls.map(([command]) => command)).toEqual(["run-A", "run-C"]);
+    await runner.stop();
+  });
+
+  it("escalates shutdown after a child ignores the first signal", async () => {
+    const { runner, children } = setup();
+    await runner.onBuildSuccess(target("A"));
+    children[0].kill.mockImplementation((signal: NodeJS.Signals) => {
+      children[0].killed = true;
+      if (signal === "SIGKILL") children[0].emit("exit", null, signal);
+      return true;
+    });
+    const stopped = runner.stop();
+    await vi.advanceTimersByTimeAsync(5000);
+    await stopped;
+    expect(children[0].kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
+  });
+});

--- a/test/config-reload-lifecycle.test.ts
+++ b/test/config-reload-lifecycle.test.ts
@@ -453,6 +453,22 @@ describe("artifact-owned restarts", () => {
     await runner.stop();
   });
 
+  it("waits through timer-sized chunks for a long restart delay", async () => {
+    const { runner, children } = setup();
+    await runner.onBuildSuccess(target("A"));
+    const b = target("B");
+    b.autoRun!.restartDelayMs = 2_147_483_648;
+    await runner.updateTarget(b);
+    await runner.onBuildSuccess(b);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(children[0].kill).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(2_147_483_646);
+    expect(children[0].kill).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(vi.mocked(spawn).mock.calls.map(([command]) => command)).toEqual(["run-A", "run-B"]);
+    await runner.stop();
+  });
+
   it("does not strand a build success arriving as a restart finishes", async () => {
     const { runner } = setup();
     const createChild = vi.mocked(spawn).getMockImplementation()!;

--- a/test/watchman-subscription-lifecycle.test.ts
+++ b/test/watchman-subscription-lifecycle.test.ts
@@ -1,0 +1,35 @@
+import { EventEmitter } from "node:events";
+import { expect, it, vi } from "vitest";
+import { createMockLogger } from "./helpers.js";
+import { createWatchmanClient } from "../src/utils/watchman-wrapper.js";
+import { WatchmanClient } from "../src/watchman.js";
+
+vi.mock("../src/utils/watchman-wrapper.js", () => ({ createWatchmanClient: vi.fn() }));
+
+it("replaces subscription handlers and removes them on unsubscribe", async () => {
+  const transport = Object.assign(new EventEmitter(), {
+    command: vi.fn((args: string[], callback: (error: null, result: object) => void) => {
+      callback(null, args[0] === "watch-project" ? { watch: "/project" } : { clock: "c:1:1" });
+    }),
+  });
+  vi.mocked(createWatchmanClient).mockReturnValue(transport);
+  const client = new WatchmanClient(createMockLogger());
+  await client.watchProject("/project");
+  const oldCallback = vi.fn();
+  const currentCallback = vi.fn();
+  const expression = { expression: ["match", "src/*.ts", "wholename"], fields: ["name"] };
+  await client.subscribe("/project", "source", expression, oldCallback);
+  await client.subscribe("/project", "source", expression, currentCallback);
+  transport.emit("subscription", {
+    subscription: "source",
+    files: [{ name: "src/app.ts", exists: true }],
+  });
+  expect(oldCallback).not.toHaveBeenCalled();
+  expect(currentCallback).toHaveBeenCalledTimes(1);
+  await client.unsubscribe("source");
+  transport.emit("subscription", {
+    subscription: "source",
+    files: [{ name: "src/app.ts", exists: true }],
+  });
+  expect(currentCallback).toHaveBeenCalledTimes(1);
+});

--- a/tests/daemon-no-targets.test.ts
+++ b/tests/daemon-no-targets.test.ts
@@ -103,7 +103,7 @@ describe.skipIf(skipLongRuns)("Daemon with no enabled targets", () => {
     await writeFile(configPath, JSON.stringify(config, null, 2));
     await expect
       .poll(() => daemonOutput, { timeout: 10_000 })
-      .toContain("Configuration reloaded successfully");
+      .toContain("Watching 1 target(s): **/*.js");
     await writeFile(join(testDir, "trigger.js"), "// trigger the newly enabled target\n");
 
     await expect


### PR DESCRIPTION
Editing an executable target could leave the daemon building and launching with its previous command, environment, and output path. Repeated configuration edits could also lose the configuration watch or dispatch stale callbacks.

Each build now retains its configuration through its asynchronous hooks, while builds started after a reload use the current settings. Successful results retain their output description and producing target through auto-run restarts without persisting environment data. Reloads run in order; target-type changes validate and replace specialized builders; retries follow configuration updates but cannot cross a removal/re-add boundary. Retired builders cannot deliver completions to replacement runners.

This is the maintainer successor to #210. Thanks @devYRPauli for the original report and reproduction. Same-type settings changes for non-executable targets and post-build hook edits retain their existing daemon-restart requirement, now documented explicitly. The changelog is collected in #222, which must land after this PR.

Validation:

- Build, lint, and typecheck passed. The full suite passed 761 tests with 31 repository skips; the temporary combined candidate with #222's dependency versions passed the same suite.
- Built-library baseline: applying configuration B after A still produced A on main; this branch produced B using the real builder and subprocess path.
- Real built CLI, foreground daemon, real Watchman, and real build/auto-run children: both intelligent-queue and direct-build modes produced and launched separate A, B, and E artifacts with matching arguments/environment. C failed without redirecting B's pending launch. Overlapping disable/re-enable saves committed the latest watch path, and server subscription inspection confirmed the obsolete path was removed.
- The Mac's automatic filesystem-event delivery was unreliable, so the multi-reload CLI fixture used a task-owned Watchman server and explicit Watchman rescans. The full suite's foreground-daemon test also passed after fixing its startup-message readiness race.
- Real built integration runs verified test/executable type changes, corrected retry commands without new source events, and cancellation of a removed/re-added target's old retry.

Exact-head CI and final review status are recorded in the proof comment. No merge, version bump, tag, or publication is included.
