### PR TITLE
fix: preserve panel settings and secure pi-tui diagnostics

### DIFF
--- a/docs/panel.md
+++ b/docs/panel.md
@@ -70,6 +70,12 @@ Behavior:
 - Use non-zero exit codes to surface “needs attention” badges in the table for row placements.
 - For long-running checks, raise `timeoutSeconds` rather than stretching `refreshSeconds` if you need frequent updates.
 
+## Terminal settings and diagnostics
+- `PI_HARDWARE_CURSOR=1` enables the hardware cursor when a component supplies a cursor position.
+- `PI_CLEAR_ON_SHRINK=1` clears trailing content when a panel frame becomes shorter. Both settings remain disabled when unset or set to any value other than `1`.
+- Renderer crash diagnostics are stored in `~/.poltergeist-panel/pi-tui-crash.log`. The directory and files are restricted to the current user (0700/0600 on POSIX; an explicit current-user-only ACL on Windows); unsafe existing paths stop panel startup instead of falling back to shared temporary storage. Crash dumps can include displayed build logs, so inspect them before sharing.
+- `PI_TUI_DEBUG_REDRAW=1` records renderer redraw diagnostics in the same private directory.
+
 ## Troubleshooting
 - If a summary script never shows output: ensure the command prints something to stdout; empty output is treated as “clean” and hidden.
 - If the panel flickers between modes: verify your `placement` choices—use `row` for always-visible entries, `summary` for tabbed.

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "oracle": "oracle"
   },
   "dependencies": {
-    "@earendil-works/pi-tui": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.85.1",
     "@logtape/logtape": "^2.3.3",
     "arkregex": "^0.0.8",
     "chalk": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@earendil-works/pi-tui':
-        specifier: ^0.84.4
-        version: 0.84.4
+        specifier: ^0.85.1
+        version: 0.85.1
       '@logtape/logtape':
         specifier: ^2.3.3
         version: 2.3.3
@@ -129,8 +129,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@earendil-works/pi-tui@0.84.4':
-    resolution: {integrity: sha512-nPUnwDkLtupPXnZQYrCwPFcuTydCDqTY6ZbFqhsL4S4kVq0AT418kPa/6uXwtaCD+MjBNBltb7ScTYX65yeE1w==}
+  '@earendil-works/pi-tui@0.85.1':
+    resolution: {integrity: sha512-OIzw9efInmO4WOBnD4TxcTdBjmzvYJpzslkgoUro946nEGoYWg5rwv1p4fDt3/JvMx9QybryUCUwlm7j8Dreig==}
     engines: {node: '>=22.19.0'}
 
   '@epic-web/invariant@1.0.0':
@@ -1391,7 +1391,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@earendil-works/pi-tui@0.84.4':
+  '@earendil-works/pi-tui@0.85.1':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5

--- a/src/panel/panel-app.ts
+++ b/src/panel/panel-app.ts
@@ -8,7 +8,6 @@ import {
   ProcessTerminal,
   Spacer,
   Text,
-  TuiMainScreen,
 } from "@earendil-works/pi-tui";
 import wrapAnsi from "wrap-ansi";
 
@@ -36,6 +35,7 @@ import {
   splitStatusScripts,
 } from "./render-utils.js";
 import { buildTargetRows, type TargetRow } from "./target-tree.js";
+import { createPanelTui, getPanelLogDirectory, preparePanelLogs } from "./terminal.js";
 import { limitSummaryLines } from "./text-utils.js";
 import type { PanelSnapshot, TargetPanelEntry } from "./types.js";
 import { buildPanelViewState, type PanelViewState } from "./view-state.js";
@@ -190,7 +190,8 @@ export class PanelApp {
   private readonly controller: StatusPanelController;
   private readonly logger: Logger;
   private readonly terminal = new ProcessTerminal();
-  private readonly tui = new TuiMainScreen(this.terminal);
+  private readonly logDirectory = getPanelLogDirectory();
+  private readonly tui = createPanelTui(this.terminal, this.logDirectory);
   private readonly inputBridge = new InputBridge((input) => {
     this.handleInput(input);
   });
@@ -273,6 +274,8 @@ export class PanelApp {
     if (this.exitPromise) {
       return this.exitPromise;
     }
+
+    preparePanelLogs(this.logDirectory);
 
     this.exitPromise = new Promise((resolve) => {
       this.exitResolver = resolve;

--- a/src/panel/terminal.ts
+++ b/src/panel/terminal.ts
@@ -1,0 +1,89 @@
+import {
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { type Terminal, TuiMainScreen } from "@earendil-works/pi-tui";
+import { secureWindowsLogPath } from "./windows-log-acl.js";
+
+export function getPanelLogDirectory(): string {
+  return join(homedir(), ".poltergeist-panel");
+}
+
+export function createPanelTui(terminal: Terminal, logDirectory: string): TuiMainScreen {
+  const tui = new TuiMainScreen(terminal, process.env.PI_HARDWARE_CURSOR === "1", logDirectory);
+  tui.setClearOnShrink(process.env.PI_CLEAR_ON_SHRINK === "1");
+  return tui;
+}
+
+// pi-tui writes these paths itself, so secure them before starting the renderer.
+export function preparePanelLogs(directory: string): void {
+  if (process.platform === "win32") {
+    secureWindowsLogPath(directory, false, true);
+  } else {
+    try {
+      mkdirSync(directory, { mode: 0o700 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+  }
+  const directoryStat = lstatSync(directory);
+  const uid = process.getuid?.();
+  if (!directoryStat.isDirectory() || (uid !== undefined && directoryStat.uid !== uid)) {
+    throw new Error(
+      `Panel log directory must be owned by the current user and not a symlink: ${directory}`,
+    );
+  }
+  if (process.platform !== "win32") {
+    const fd = openSync(
+      directory,
+      constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+    );
+    try {
+      if (fstatSync(fd).uid !== uid)
+        throw new Error(`Panel log directory owner changed: ${directory}`);
+      fchmodSync(fd, 0o700);
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  for (const name of ["pi-tui-crash.log", "pi-tui-debug.log"]) {
+    const file = join(directory, name);
+    // Exclusive creation distinguishes new files from existing paths on Windows.
+    let created = false;
+    let fd: number;
+    const flags = constants.O_WRONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK;
+    try {
+      fd = openSync(file, flags | constants.O_CREAT | constants.O_EXCL, 0o600);
+      created = true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      if (lstatSync(file).isSymbolicLink())
+        throw new Error(`Panel log must not be a symlink: ${file}`);
+      fd = openSync(file, flags);
+    }
+    try {
+      const stat = fstatSync(fd);
+      if (!stat.isFile() || stat.nlink !== 1 || (uid !== undefined && stat.uid !== uid)) {
+        throw new Error(`Panel log must be a regular file owned by the current user: ${file}`);
+      }
+      // chmod cannot revoke descriptors another user opened before startup.
+      if (process.platform !== "win32" && (stat.mode & 0o077) !== 0) {
+        throw new Error(
+          `Panel log is accessible to other users; move it aside before starting: ${file}`,
+        );
+      }
+      if (process.platform === "win32") secureWindowsLogPath(file, created);
+      else fchmodSync(fd, 0o600);
+    } finally {
+      closeSync(fd);
+    }
+  }
+}

--- a/src/panel/windows-log-acl.ts
+++ b/src/panel/windows-log-acl.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from "node:child_process";
+
+// Node's POSIX permission bits do not restrict Windows access-control lists.
+export function secureWindowsLogPath(path: string, created: boolean, directory = false): void {
+  const script = `
+$ErrorActionPreference = 'Stop'
+$path = $env:POLTERGEIST_PANEL_LOG_PATH
+$user = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+if ($env:POLTERGEIST_PANEL_LOG_DIRECTORY -eq '1') {
+  $acl = New-Object System.Security.AccessControl.DirectorySecurity
+  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule($user, 'FullControl', 'ContainerInherit,ObjectInherit', 'None', 'Allow')
+} else {
+  $acl = New-Object System.Security.AccessControl.FileSecurity
+  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule($user, 'FullControl', 'Allow')
+}
+$acl.SetOwner($user)
+$acl.SetAccessRuleProtection($true, $false)
+$acl.AddAccessRule($rule)
+if ($env:POLTERGEIST_PANEL_LOG_DIRECTORY -eq '1') {
+  # Apply the ACL atomically at creation, never expose a newly-created directory.
+  [System.IO.Directory]::CreateDirectory($path, $acl) | Out-Null
+}
+$item = Get-Item -LiteralPath $path -Force
+if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) { throw 'Panel logs must not use reparse points' }
+if ($env:POLTERGEIST_PANEL_LOG_CREATED -eq '1') { Set-Acl -LiteralPath $path -AclObject $acl }
+$actual = Get-Acl -LiteralPath $path
+if (!$actual.AreAccessRulesProtected -or $actual.GetOwner([System.Security.Principal.SecurityIdentifier]) -ne $user) { throw 'Could not secure panel log ownership' }
+foreach ($entry in $actual.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier])) {
+  if ($entry.IdentityReference -ne $user -or $entry.AccessControlType -ne 'Allow') { throw 'Could not restrict panel log access' }
+}
+`;
+  execFileSync(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-EncodedCommand",
+      Buffer.from(script, "utf16le").toString("base64"),
+    ],
+    {
+      env: {
+        ...process.env,
+        POLTERGEIST_PANEL_LOG_PATH: path,
+        POLTERGEIST_PANEL_LOG_CREATED: created ? "1" : "0",
+        POLTERGEIST_PANEL_LOG_DIRECTORY: directory ? "1" : "0",
+      },
+      stdio: "pipe",
+      timeout: 15_000,
+      windowsHide: true,
+    },
+  );
+}

--- a/test/panel/terminal.test.ts
+++ b/test/panel/terminal.test.ts
@@ -1,0 +1,150 @@
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ProcessTerminal } from "@earendil-works/pi-tui";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPanelTui, preparePanelLogs } from "../../src/panel/terminal.js";
+
+const roots: string[] = [];
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "panel-logs-test-"));
+  roots.push(root);
+  return { root, directory: join(root, "logs") };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("panel terminal compatibility", () => {
+  it.each([undefined, "0", "false", "1"])("preserves PI_*=%s behavior", (value) => {
+    vi.stubEnv("PI_HARDWARE_CURSOR", value);
+    vi.stubEnv("PI_CLEAR_ON_SHRINK", value);
+    const tui = createPanelTui(new ProcessTerminal(), "/unused");
+    expect(tui.getShowHardwareCursor()).toBe(value === "1");
+    expect(tui.getClearOnShrink()).toBe(value === "1");
+  });
+
+  it("forwards each setting independently", () => {
+    vi.stubEnv("PI_HARDWARE_CURSOR", "1");
+    vi.stubEnv("PI_CLEAR_ON_SHRINK", "0");
+    const tui = createPanelTui(new ProcessTerminal(), "/unused");
+    expect(tui.getShowHardwareCursor()).toBe(true);
+    expect(tui.getClearOnShrink()).toBe(false);
+  });
+});
+
+describe("private panel logs", () => {
+  it.skipIf(process.platform !== "win32")(
+    "creates private Windows ACLs and rejects previously permissive paths",
+    () => {
+      const { directory } = fixture();
+      preparePanelLogs(directory);
+      const run = (script: string) =>
+        execFileSync(
+          "powershell.exe",
+          [
+            "-NoProfile",
+            "-NonInteractive",
+            "-EncodedCommand",
+            Buffer.from(script, "utf16le").toString("base64"),
+          ],
+          {
+            env: { ...process.env, PANEL_TEST_DIRECTORY: directory },
+            encoding: "utf8",
+          },
+        );
+      const result = run(`
+$ErrorActionPreference = 'Stop'
+$user = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+$paths = @($env:PANEL_TEST_DIRECTORY, (Join-Path $env:PANEL_TEST_DIRECTORY 'pi-tui-crash.log'), (Join-Path $env:PANEL_TEST_DIRECTORY 'pi-tui-debug.log'))
+foreach ($path in $paths) {
+  $acl = Get-Acl -LiteralPath $path
+  if (!$acl.AreAccessRulesProtected -or $acl.GetOwner([System.Security.Principal.SecurityIdentifier]) -ne $user) { throw 'Unexpected owner or inheritance' }
+  $rules = @($acl.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier]))
+  if ($rules.Count -ne 1 -or $rules[0].IdentityReference -ne $user -or $rules[0].AccessControlType -ne 'Allow') { throw 'Unexpected access rules' }
+}
+'private'
+`);
+      expect(result.trim()).toBe("private");
+      run(`
+$ErrorActionPreference = 'Stop'
+$paths = @($env:PANEL_TEST_DIRECTORY, (Join-Path $env:PANEL_TEST_DIRECTORY 'pi-tui-crash.log'))
+foreach ($path in $paths) {
+  $acl = Get-Acl -LiteralPath $path
+  $everyone = New-Object System.Security.Principal.SecurityIdentifier('S-1-1-0')
+  $acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule($everyone, 'Read', 'Allow')))
+  Set-Acl -LiteralPath $path -AclObject $acl
+}
+`);
+      expect(() => preparePanelLogs(directory)).toThrow();
+    },
+  );
+  it("creates private files and preserves old crash contents on repeated starts", () => {
+    const { directory } = fixture();
+    preparePanelLogs(directory);
+    const crash = join(directory, "pi-tui-crash.log");
+    writeFileSync(crash, "previous diagnostic");
+    preparePanelLogs(directory);
+    expect(readFileSync(crash, "utf8")).toBe("previous diagnostic");
+    if (process.platform !== "win32") {
+      expect(lstatSync(directory).mode & 0o777).toBe(0o700);
+      expect(lstatSync(crash).mode & 0o777).toBe(0o600);
+      expect(lstatSync(join(directory, "pi-tui-debug.log")).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "rejects existing permissive logs before they can receive new diagnostics",
+    () => {
+      const { directory } = fixture();
+      preparePanelLogs(directory);
+      chmodSync(directory, 0o777);
+      const crash = join(directory, "pi-tui-crash.log");
+      chmodSync(crash, 0o666);
+      expect(() => preparePanelLogs(directory)).toThrow("accessible to other users");
+      expect(lstatSync(directory).mode & 0o777).toBe(0o700);
+      expect(lstatSync(crash).mode & 0o777).toBe(0o666);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects directory symlinks without changing the destination",
+    () => {
+      const { root, directory } = fixture();
+      const target = join(root, "target");
+      mkdirSync(target, { mode: 0o755 });
+      symlinkSync(target, directory);
+      expect(() => preparePanelLogs(directory)).toThrow();
+      expect(lstatSync(target).mode & 0o777).toBe(0o755);
+    },
+  );
+
+  it.skipIf(process.platform === "win32").each(["symlink", "hardlink"])(
+    "rejects an existing %s log without modifying its target",
+    (kind) => {
+      const { root, directory } = fixture();
+      mkdirSync(directory);
+      const target = join(root, "target");
+      writeFileSync(target, "unrelated data", { mode: 0o644 });
+      const file = join(directory, "pi-tui-crash.log");
+      if (kind === "symlink") symlinkSync(target, file);
+      else linkSync(target, file);
+      expect(() => preparePanelLogs(directory)).toThrow();
+      expect(readFileSync(target, "utf8")).toBe("unrelated data");
+      expect(lstatSync(target).mode & 0o777).toBe(0o644);
+    },
+  );
+});


### PR DESCRIPTION
Upgrades [pi-tui](https://github.com/earendil-works/pi/tree/v0.85.1/packages/tui) to 0.85.1 while preserving Poltergeist’s existing terminal settings and keeping renderer diagnostics private. Replaces the dependency-only update in #221; thanks @dependabot.

pi-tui no longer reads the inherited application environment variables and otherwise writes overflow crash dumps to a predictable temporary path. The panel now explicitly forwards `PI_HARDWARE_CURSOR` and `PI_CLEAR_ON_SHRINK` (`1` enables; unset and other values remain false), and prepares `~/.poltergeist-panel` with 0700 directory / 0600 log permissions on POSIX and verified current-user-only Windows ACLs. It rejects symlinks, non-regular files, wrong ownership, hard-linked log files, existing permissive logs without truncating existing diagnostics.

Validation:
- Build, lint, typecheck and the complete CI test configuration passed: 746 passed, 32 skipped.
- Eleven new regression cases cover environment forwarding, private creation and rejection of permissive files, diagnostic preservation, and unsafe existing paths.
- Real built CLI in a PTY: unset/explicit settings, frame shrink, resize, keyboard quit, raw-mode/cursor restoration. A synthetic over-width component exercised the real upstream crash handler: exit 1, private 4277-byte crash dump, 0700/0600 permissions. Normal runs exit 0 and restore the alternate buffer. The existing uncaught-overflow path does not leave the alternate buffer; this change preserves that behavior.
- Clean Windows VM: Node 24.20.0 build, 7 platform-relevant regression tests passed (4 POSIX-only skipped), built CLI version smoke, and real pi-tui overflow integration produced a 233-byte crash dump whose current-user-only ACL was revalidated.
- The broader local suite passed 770 tests with 31 skipped; its existing foreground-daemon hot-reload test timed out waiting for macOS Watchman delivery. The CI configuration already excludes that test. A separate initial state-persistence timing failure passed with reduced concurrency.

The pi-tui changelog bullet is reserved for the authorized 2.1.7 release commit so this PR stays independent of the notes changes.

The later macOS extended-ACL correction is tracked separately; see the follow-up comment. This merged PR contains head `7127685b00b2d05438df542209daf9f309bff40f`.
