### PR TITLE
fix: reject extended ACLs on panel diagnostics

### DIFF
--- a/docs/panel.md
+++ b/docs/panel.md
@@ -73,7 +73,7 @@ Behavior:
 ## Terminal settings and diagnostics
 - `PI_HARDWARE_CURSOR=1` enables the hardware cursor when a component supplies a cursor position.
 - `PI_CLEAR_ON_SHRINK=1` clears trailing content when a panel frame becomes shorter. Both settings remain disabled when unset or set to any value other than `1`.
-- Renderer crash diagnostics are stored in `~/.poltergeist-panel/pi-tui-crash.log`. The directory and files are restricted to the current user (0700/0600 on POSIX; an explicit current-user-only ACL on Windows); unsafe existing paths stop panel startup instead of falling back to shared temporary storage. Crash dumps can include displayed build logs, so inspect them before sharing.
+- Renderer crash diagnostics are stored in `~/.poltergeist-panel/pi-tui-crash.log`. The directory and files are restricted to the current user (0700/0600 on POSIX; an explicit current-user-only ACL on Windows); unsafe existing paths, including macOS paths with extended ACLs, stop panel startup instead of falling back to shared temporary storage. Crash dumps can include displayed build logs, so inspect them before sharing.
 - `PI_TUI_DEBUG_REDRAW=1` records renderer redraw diagnostics in the same private directory.
 
 ## Troubleshooting

--- a/src/panel/terminal.ts
+++ b/src/panel/terminal.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import {
   closeSync,
   constants,
@@ -22,6 +23,18 @@ export function createPanelTui(terminal: Terminal, logDirectory: string): TuiMai
   return tui;
 }
 
+function rejectDarwinAcl(path: string): void {
+  if (process.platform !== "darwin") return;
+  // Unlike POSIX ACL masks, Darwin ACL grants can bypass the mode bits.
+  const listing = execFileSync("/bin/ls", ["-lde", path], {
+    encoding: "utf8",
+    env: { ...process.env, LC_ALL: "C" },
+  });
+  if (/^\s*\d+: /m.test(listing)) {
+    throw new Error(`Panel log path has an extended ACL; move it aside before starting: ${path}`);
+  }
+}
+
 // pi-tui writes these paths itself, so secure them before starting the renderer.
 export function preparePanelLogs(directory: string): void {
   if (process.platform === "win32") {
@@ -40,6 +53,7 @@ export function preparePanelLogs(directory: string): void {
       `Panel log directory must be owned by the current user and not a symlink: ${directory}`,
     );
   }
+  rejectDarwinAcl(directory);
   if (process.platform !== "win32") {
     const fd = openSync(
       directory,
@@ -74,6 +88,7 @@ export function preparePanelLogs(directory: string): void {
       if (!stat.isFile() || stat.nlink !== 1 || (uid !== undefined && stat.uid !== uid)) {
         throw new Error(`Panel log must be a regular file owned by the current user: ${file}`);
       }
+      rejectDarwinAcl(file);
       // chmod cannot revoke descriptors another user opened before startup.
       if (process.platform !== "win32" && (stat.mode & 0o077) !== 0) {
         throw new Error(

--- a/test/panel/terminal.test.ts
+++ b/test/panel/terminal.test.ts
@@ -47,6 +47,21 @@ describe("panel terminal compatibility", () => {
 });
 
 describe("private panel logs", () => {
+  it.skipIf(process.platform !== "darwin").each(["directory", "file"])(
+    "rejects a Darwin %s ACL even when mode bits are private",
+    (kind) => {
+      const { directory } = fixture();
+      preparePanelLogs(directory);
+      const path = kind === "directory" ? directory : join(directory, "pi-tui-crash.log");
+      execFileSync("/bin/chmod", [
+        "+a",
+        "everyone allow read,readattr,readextattr,readsecurity",
+        path,
+      ]);
+      expect(lstatSync(path).mode & 0o777).toBe(kind === "directory" ? 0o700 : 0o600);
+      expect(() => preparePanelLogs(directory)).toThrow("extended ACL");
+    },
+  );
   it.skipIf(process.platform !== "win32")(
     "creates private Windows ACLs and rejects previously permissive paths",
     () => {


### PR DESCRIPTION
Reject macOS extended ACLs before accepting panel diagnostic paths. BSD mode bits alone do not establish privacy on Darwin: an ACL can grant another account read access while a log still reports 0600. The panel now rejects those paths before rendering, preserving existing diagnostics.

This completes the hardening from #224, which merged before its final branch review identified the macOS ACL case. The pi-tui dependency update and explicit environment forwarding are already on main; thanks @dependabot for initiating that update.

Validation:
- Build, lint, and the CI test configuration passed: 748 tests passed, 32 skipped.
- Two real macOS ACL regression cases cover directory and file grants that bypass private mode bits.
- Built CLI PTY proof: a 0600 log with an extended ACL is rejected (exit 1), its existing contents remain intact, and the alternate buffer is restored. Normal settings, resize, shrink, and overflow proof also passed.
- The broader suite’s existing Watchman foreground-daemon test remains unreliable on this host, as documented on #224.

Release notes will be included in the authorized 2.1.7 release commit.
